### PR TITLE
[feat][CCS-15] OAuth2 구글 로그인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,16 @@ dependencies {
 
 	// webClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// jwt 관련 라이브러리
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/trend_now/backend/alarm/domain/AlarmSettings.java
+++ b/backend/src/main/java/com/trend_now/backend/alarm/domain/AlarmSettings.java
@@ -2,7 +2,7 @@ package com.trend_now.backend.alarm.domain;
 
 
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,7 +42,7 @@ public class AlarmSettings extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 
     public AlarmSettings(AlarmSettingType alarmSettingType, LocalTime alarmSettingTime,
             String alarmSettingKeyword) {

--- a/backend/src/main/java/com/trend_now/backend/alarm/domain/Alarms.java
+++ b/backend/src/main/java/com/trend_now/backend/alarm/domain/Alarms.java
@@ -1,7 +1,7 @@
 package com.trend_now.backend.alarm.domain;
 
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -38,5 +38,5 @@ public class Alarms extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 }

--- a/backend/src/main/java/com/trend_now/backend/alarm/domain/Fcms.java
+++ b/backend/src/main/java/com/trend_now/backend/alarm/domain/Fcms.java
@@ -1,7 +1,7 @@
 package com.trend_now.backend.alarm.domain;
 
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -33,5 +33,5 @@ public class Fcms extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 }

--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 // 특정 url 패턴에 대해서는 security filter에서 제외(Authentication 객체를 안만들겠다는 의미)
                 // todo. 비회원도 사용 가능한 API의 uri 패턴 추가
                 .authorizeHttpRequests(a -> a.requestMatchers(
-                                "/member/create", "/member/doLogin", "/member/google/doLogin", "/swagger-ui/**", "/v3/api-docs/**")
+                                "/api/v1/member/google/doLogin", "/swagger-ui/**", "/v3/api-docs/**")
                         .permitAll().anyRequest().authenticated())
 
                 /**

--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.trend_now.backend.config;
+
+import com.trend_now.backend.config.auth.JwtTokenFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenFilter jwtTokenFilter;
+
+    @Bean
+    public PasswordEncoder makePassword() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain myFilter(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // 프론트엔드가 별도 존재하므로 CSRF 공격 보안에 대해 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // Basic 인증은 사용자 이름과 비밀번호를 Base64 인코딩하여 인증값으로 사용한다. 여기서는 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 토큰 방식을 이용할 것이니 sessionManagement 비활성화
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 특정 url 패턴에 대해서는 security filter에서 제외(Authentication 객체를 안만들겠다는 의미)
+                // todo. 비회원도 사용 가능한 API의 uri 패턴 추가
+                .authorizeHttpRequests(a -> a.requestMatchers(
+                                "/member/create", "/member/doLogin", "/member/google/doLogin", "/swagger-ui/**", "/v3/api-docs/**")
+                        .permitAll().anyRequest().authenticated())
+
+                /**
+                 *  UsernamePasswordAuthenticationFilter는 Spring Security에서 제공하는 로그인 폼을 의미한다.
+                 *  해당 UsernamePasswordAuthenticationFilter 필터 전에, JwtTokenFilter를 사용하여 Authentication 객체를 생성
+                 *  UsernamePasswordAuthenticationFilter를 무용지물로 만드는 것
+                 */
+                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    /**
+     *  CORS 허용하는 도메인들을 명시한다.
+     *  허용하지 않는 도메인의 요청은 에러를 반환시켜 프론트엔드와 통신이 불가능해진다.
+     *  해당 메서드에 개발용 프론트엔드, 배포용 프론트엔드 도메인을 추가한다.
+     *
+     *  todo. 추후에 프론트엔드 도메인 추가
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));    // 개발 프론트엔드 도메인 허용
+        configuration.setAllowedMethods(Arrays.asList("*"));    // 모든 HTTP 메서드 허용
+        configuration.setAllowedHeaders(Arrays.asList("*"));    // 모든 헤더 값 허용
+        configuration.setAllowCredentials(true);    // 자격 증명을 허용(Authorization 헤더를 허용 목적)
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        // 모든 url 패턴에 대해 CORS 허용 설정
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
@@ -40,7 +40,7 @@ public class JwtTokenFilter extends GenericFilter {
         try {
             if (token != null) {
                 if (!token.substring(0, 7).equals("Bearer ")) {
-                    log.error("[JwtTokenFilter] : Bearer 형식이 아닙니다.");
+                    log.error("[JwtTokenFilter.doFilter] : Bearer 형식이 아닙니다.");
                     throw new AuthenticationException("Bearer 형식이 아닙니다.");
                 }
 
@@ -83,7 +83,7 @@ public class JwtTokenFilter extends GenericFilter {
 
         // JWT 검증에서 예외가 발생하면 doFilter() 메서드를 통해 필터 체인에 접근하지 않고 사용자에게 에러를 반환
         catch (Exception e) {
-            log.error("");
+            log.error("[JwtTokenFilter.doFilter] : JWT이 올바르지 않습니다.");
             e.printStackTrace();
             httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
             httpServletResponse.setContentType("application/json");

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
@@ -1,0 +1,94 @@
+package com.trend_now.backend.config.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class JwtTokenFilter extends GenericFilter {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // HTTP 내부 데이터를 조금 더 편하게 쓸려고 다운캐스팅 진행
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+
+        // HttpServletRequest 객체 Header에서 토큰 값 추출
+        String token = httpServletRequest.getHeader("Authorization");
+
+        try {
+            if (token != null) {
+                if (!token.substring(0, 7).equals("Bearer ")) {
+                    log.error("[JwtTokenFilter] : Bearer 형식이 아닙니다.");
+                    throw new AuthenticationException("Bearer 형식이 아닙니다.");
+                }
+
+                String jwtToken = token.substring(7);
+
+                /**
+                 *  JWT 검증 및 claims(payload) 추출
+                 *  - 입력된 JWT 토큰의 (헤더 + 페이로드) 부분을 secretKey를 가지고 헤더에 명시된 암호화 알고리즘을 진행
+                 *  - 암호화 알고리즘을 통해 나온 문자열인 서명을 입력받은 토큰의 서명 부분과 비교
+                 *  - 일치하면 true, 불일치면 false 반환
+                 *  - getBody()를 통해 페이로드 부분(Claims) 추출
+                 */
+                Claims claims = Jwts.parserBuilder()
+                        .setSigningKey(secretKey)
+                        .build()
+                        .parseClaimsJws(jwtToken)
+                        .getBody();
+
+
+                /**
+                 *  인증 객체 범위
+                 *  - SecurityContextHolder 객체는 SecurityContext 객체를 감싸고 있다.
+                 *  - SecurityContext 객체는 Authentication 객체를 감싸고 있다.
+                 *  - Authentication 객체는 사용자 인증 정보를 가지고 있다.
+                 *
+                 *  Spring 전역에서 SecurityContextHolder 객체를 사용할 수 있기에, 사용자 인증 정보를 바로 확인 가능하다.
+                 *  - String 사용자 정보 = SecurityContextHolder.getContext().getAuthentication().getName();
+                 */
+
+                // Authentication 객체 생성
+                List<GrantedAuthority> authorities = new ArrayList<>();
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + claims.get("role")));
+                UserDetails userDetails = new User(claims.getSubject(), "", authorities);   // password는 의미가 없어 빈 문자열 입력
+                Authentication authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, jwtToken, userDetails.getAuthorities());
+            }
+
+            chain.doFilter(request, response);
+        }
+
+        // JWT 검증에서 예외가 발생하면 doFilter() 메서드를 통해 필터 체인에 접근하지 않고 사용자에게 에러를 반환
+        catch (Exception e) {
+            log.error("");
+            e.printStackTrace();
+            httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+            httpServletResponse.setContentType("application/json");
+            httpServletResponse.getWriter().write("invalid token");
+        }
+
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
@@ -32,13 +32,12 @@ public class JwtTokenProvider {
                 SignatureAlgorithm.HS512.getJcaName());
     }
 
-    public String createToken(String email, String role) {
-        /**
-         *  Claims은 JWT의 페이로드의 데이터 단위
-         *  - setSubject() 메서드를 통해 JWT를 인증할 식별자를 원하는 데이터로 지정 가능
-         */
-        Claims claims = Jwts.claims().setSubject(email);
-        claims.put("role", role);   // private Claim으로 협의하에 사용
+    /**
+     *  JWT 토큰을 생성할 때, 사용자 식별이 가능한 PK 값을 이용
+     *  - setSubject() 메서드를 통해 memberId를 JWT의 sub Claim에 저장
+     */
+    public String createToken(Long memberId) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));
         Date now = new Date();
         String token = Jwts.builder()
                 .setClaims(claims)

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
@@ -46,6 +46,7 @@ public class JwtTokenProvider {
                 .signWith(SECRET_KEY)
                 .compact();
 
+        log.info("[JwtTokenProvider.createToken] 생성된 JWT = {}", token);
         return token;
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenProvider.java
@@ -1,0 +1,52 @@
+package com.trend_now.backend.config.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+    private final String secretKey;     // 인코딩된 secret key
+    private final int expiration;       // application.yml 에서 가져온 분 단위의 만료 시간
+    private Key SECRET_KEY;     // 서명에 사용되는 secret key
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, @Value("${jwt.expiration}") int expiration) {
+        this.secretKey = secretKey;
+        this.expiration = expiration;
+
+        /**
+         *  JWT 서명에 사용되는 secret key 생성
+         *  - application.yml에서 가져온 인코딩된 secretKey를 디코딩한 후,
+         *  - HS512 알고리즘을 통해 암호화
+         */
+        this.SECRET_KEY = new SecretKeySpec(java.util.Base64.getDecoder().decode(secretKey),
+                SignatureAlgorithm.HS512.getJcaName());
+    }
+
+    public String createToken(String email, String role) {
+        /**
+         *  Claims은 JWT의 페이로드의 데이터 단위
+         *  - setSubject() 메서드를 통해 JWT를 인증할 식별자를 원하는 데이터로 지정 가능
+         */
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("role", role);   // private Claim으로 협의하에 사용
+        Date now = new Date();
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expiration * 60 * 1000L))
+                .signWith(SECRET_KEY)
+                .compact();
+
+        return token;
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/member/application/GoogleService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/GoogleService.java
@@ -1,0 +1,106 @@
+package com.trend_now.backend.member.application;
+
+import com.trend_now.backend.config.auth.JwtTokenProvider;
+import com.trend_now.backend.member.data.vo.AccessToken;
+import com.trend_now.backend.member.data.vo.GoogleLoginResponse;
+import com.trend_now.backend.member.data.vo.GoogleProfile;
+import com.trend_now.backend.member.data.vo.AuthCodeToJwtRequest;
+import com.trend_now.backend.member.domain.Members;
+import com.trend_now.backend.member.domain.Provider;
+import com.trend_now.backend.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GoogleService {
+
+    @Value("${oauth.google.client-id}")
+    private String googleClientId;
+
+    @Value("${oauth.google.client-secret}")
+    private String googleClientSecret;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String googleRedirectUri;
+
+    private String googleUri = "https://oauth2.googleapis.com/token";
+
+
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     *  getToken(AuthCodeToJwtRequest)
+     *  - 인가 코드를 통해 JWT 토큰을 반환받는다.
+     *  - 이 과정에는 인가 코드를 통해 Access Token을 발급 받고, Access Token을 통해 구글로부터 사용자 정보를 받는다.
+     *  - 사용자 정보를 본 서비스에서 검증하여 JWT 토큰을 발급해준다.
+     */
+    public GoogleLoginResponse getToken(AuthCodeToJwtRequest authCodeToJwtRequest) {
+        AccessToken accessToken = getAccessToken(authCodeToJwtRequest.getCode());
+        GoogleProfile googleProfile = getGoogleProfile(accessToken.getAccess_token());
+
+        // socialId를 통해 회원 탐색(없으면 null 반환)
+        Members originalMember = memberRepository.findBySnsId(googleProfile.getSub()).orElse(null);
+
+        // 최초 로그인인 경우, 회원 정보 저장
+        if(originalMember == null) {
+            originalMember = memberService.createOauth(googleProfile, Provider.GOOGLE);
+        }
+
+        // JWT 토큰 발급
+        String jwtToken = jwtTokenProvider.createToken(originalMember.getId());
+
+        GoogleLoginResponse googleLoginResponse = GoogleLoginResponse.builder()
+                .memberId(originalMember.getId())
+                .jwt(jwtToken)
+                .build();
+
+        return googleLoginResponse;
+    }
+
+    // Access Token 획득 메서드
+    // RestClient를 사용해서 구글 서버와 통신
+    private AccessToken getAccessToken(String code) {
+        RestClient restClient = RestClient.create();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", googleClientId);
+        params.add("client_secret", googleClientSecret);
+        params.add("redirect_uri", googleRedirectUri);
+        params.add("grant_type", "authorization_code");
+
+        ResponseEntity<AccessToken> response = restClient.post()
+                .uri(googleUri)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(params)
+                .retrieve()     // 응답 Body 값만 추출
+                .toEntity(AccessToken.class);
+
+        log.info("[GoogleService.getAccessToken] : 응답 Access Token JSON = {}", response.getBody());
+        return response.getBody();
+    }
+
+    // 사용자 정보 획득 메서드
+    private GoogleProfile getGoogleProfile(String accessToken) {
+        RestClient restClient = RestClient.create();
+
+        ResponseEntity<GoogleProfile> response =  restClient.get()
+                .uri("https://openidconnect.googleapis.com/v1/userinfo")
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(GoogleProfile.class);
+
+        log.info("[GoogleService.getGoogleProfile] : 응답 profile JSON = {}", response.getBody());
+        return response.getBody();
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -1,4 +1,4 @@
-package com.trend_now.backend.user.application;
+package com.trend_now.backend.member.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class UserService {
+public class MemberService {
 }

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -1,11 +1,33 @@
 package com.trend_now.backend.member.application;
 
+import com.trend_now.backend.member.data.vo.GoogleProfile;
+import com.trend_now.backend.member.domain.Members;
+import com.trend_now.backend.member.domain.Provider;
+import com.trend_now.backend.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public Members createOauth(GoogleProfile googleProfile, Provider provider) {
+        Members member = Members.builder()
+                .email(googleProfile.getEmail())
+                .name("test")
+                .provider(provider)
+                .snsId(googleProfile.getSub())
+                .build();
+
+        memberRepository.save(member);
+        return member;
+    }
 }

--- a/backend/src/main/java/com/trend_now/backend/member/data/vo/AccessToken.java
+++ b/backend/src/main/java/com/trend_now/backend/member/data/vo/AccessToken.java
@@ -1,0 +1,20 @@
+package com.trend_now.backend.member.data.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ *  구글에서 전달받은 Access Token 정보를 매칭하는 클래스
+ */
+@AllArgsConstructor
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)     // 없는 필드는 자동으로 무시
+public class AccessToken {
+
+    // 구글이 제공해주는 데이터이기 때문에, JSON 프로퍼티와 동일하게 변수명을 가져야 한다.
+    private final String access_token;
+    private final String expires_in;     // Access Token 만료 시간
+    private final String scope;     // 유저 정보의 범위
+    private final String id_token;       // 사용자 정보를 JWT 토큰으로 만든 것
+}

--- a/backend/src/main/java/com/trend_now/backend/member/data/vo/AuthCodeToJwtRequest.java
+++ b/backend/src/main/java/com/trend_now/backend/member/data/vo/AuthCodeToJwtRequest.java
@@ -1,0 +1,14 @@
+package com.trend_now.backend.member.data.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ *  프론트엔드에서 인가코드를 통해 JWT 토큰을 반환받을 때, 사용되는 클래스
+ */
+@AllArgsConstructor
+@Data
+public class AuthCodeToJwtRequest {
+
+    private final String code;
+}

--- a/backend/src/main/java/com/trend_now/backend/member/data/vo/GoogleLoginResponse.java
+++ b/backend/src/main/java/com/trend_now/backend/member/data/vo/GoogleLoginResponse.java
@@ -1,0 +1,15 @@
+package com.trend_now.backend.member.data.vo;
+
+import lombok.*;
+
+/**
+ *  구글 로그인 시, 반환되는 데이터
+ */
+@Data
+@AllArgsConstructor
+@Builder
+public class GoogleLoginResponse {
+
+    private final Long memberId;
+    private final String jwt;
+}

--- a/backend/src/main/java/com/trend_now/backend/member/data/vo/GoogleProfile.java
+++ b/backend/src/main/java/com/trend_now/backend/member/data/vo/GoogleProfile.java
@@ -1,0 +1,19 @@
+package com.trend_now.backend.member.data.vo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ *  구글에서 전달받은 사용자 정보를 매칭하는 클래스
+ */
+@AllArgsConstructor
+@Data
+// JsonIgnoreProperties 어노테이션을 사용하면 응답 받는 JSON 프로퍼티 중 여기에 정의되지 않은 것들에 의한 에러를 막아준다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GoogleProfile {
+
+    private final String sub;       // sub은 open_id(=social_id)를 의미
+    private final String email;
+    private final String picture;
+}

--- a/backend/src/main/java/com/trend_now/backend/member/domain/Members.java
+++ b/backend/src/main/java/com/trend_now/backend/member/domain/Members.java
@@ -6,7 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "users", uniqueConstraints = {
+@Table(name = "members", uniqueConstraints = {
         @UniqueConstraint(name = "uk_email", columnNames = {"email"}),
         @UniqueConstraint(name = "uk_sns_id", columnNames = {"snsId"}),
         @UniqueConstraint(name = "uk_provider_sns_id", columnNames = {"provider", "snsId"})
@@ -19,7 +19,7 @@ public class Members extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "member_id")
     private Long id;
 
     @Column(nullable = false, name = "name")
@@ -28,8 +28,9 @@ public class Members extends BaseEntity {
     @Column(nullable = false, name = "email")
     private String email;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "provider")
-    private String provider;
+    private Provider provider;
 
     @Column(nullable = false, name = "sns_id")
     private String snsId;

--- a/backend/src/main/java/com/trend_now/backend/member/domain/Members.java
+++ b/backend/src/main/java/com/trend_now/backend/member/domain/Members.java
@@ -1,4 +1,4 @@
-package com.trend_now.backend.user.domain;
+package com.trend_now.backend.member.domain;
 
 
 import com.trend_now.backend.config.domain.BaseEntity;
@@ -15,7 +15,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Users extends BaseEntity {
+public class Members extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/trend_now/backend/member/domain/Provider.java
+++ b/backend/src/main/java/com/trend_now/backend/member/domain/Provider.java
@@ -1,0 +1,6 @@
+package com.trend_now.backend.member.domain;
+
+public enum Provider {
+
+    GOOGLE, KAKAO, NAVER
+}

--- a/backend/src/main/java/com/trend_now/backend/member/domain/Role.java
+++ b/backend/src/main/java/com/trend_now/backend/member/domain/Role.java
@@ -1,0 +1,10 @@
+package com.trend_now.backend.member.domain;
+
+/**
+ *  권한, 역할의 Enum 클래스로 추후 확장성을 위해 생성
+ */
+public enum Role {
+
+    ADMIN, USER
+
+}

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -1,18 +1,31 @@
 package com.trend_now.backend.member.presentation;
 
+import com.trend_now.backend.config.auth.JwtTokenProvider;
+import com.trend_now.backend.member.application.GoogleService;
+import com.trend_now.backend.member.application.MemberService;
+import com.trend_now.backend.member.data.vo.AuthCodeToJwtRequest;
+import com.trend_now.backend.member.data.vo.GoogleLoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 
 @RestController
 @Tag(name = "회원 서비스", description = "회원 API")
-@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/member")
 public class MemberController {
+
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final GoogleService googleService;
 
     // 연결 확인
     @GetMapping("")
@@ -21,4 +34,16 @@ public class MemberController {
         return new ResponseEntity<>("Connection Success", HttpStatus.OK);
     }
 
+    /**
+     *  구글 인가코드를 받는 Controller
+     *  - 프론트엔드에서 구글 인가코드를 가지고 유저 정보를 반환받는 Controller
+     *  - 해당 Controller에서 HTTP Body를 통해 인가 코드를 받음
+     *  - 해당 인가 코드를 가지고 구글 서버에 사용자 정보 요청
+     *  - 사용자 정보를 통해 서비스 유저인지 확인
+     *  - 유저인 경우, JWT 토큰 발급
+     */
+    @PostMapping("/google/doLogin")
+    public ResponseEntity<GoogleLoginResponse> googleLogin(@RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
+        return new ResponseEntity<>(googleService.getToken(authCodeToJwtRequest), HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -1,4 +1,4 @@
-package com.trend_now.backend.user.presentation;
+package com.trend_now.backend.member.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Tag(name = "회원 서비스", description = "회원 API")
 @RequestMapping("/api/v1/user")
-public class UserController {
+public class MemberController {
 
     // 연결 확인
     @GetMapping("")

--- a/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
@@ -3,6 +3,12 @@ package com.trend_now.backend.member.repository;
 
 import com.trend_now.backend.member.domain.Members;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface MemberRepository extends JpaRepository<Members, Long> {
+
+    Optional<Members> findBySnsId(String socialId);
 }

--- a/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.trend_now.backend.member.repository;
+
+
+import com.trend_now.backend.member.domain.Members;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Members, Long> {
+}

--- a/backend/src/main/java/com/trend_now/backend/post/domain/PostLikes.java
+++ b/backend/src/main/java/com/trend_now/backend/post/domain/PostLikes.java
@@ -1,7 +1,7 @@
 package com.trend_now.backend.post.domain;
 
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,7 +30,7 @@ public class PostLikes extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")

--- a/backend/src/main/java/com/trend_now/backend/post/domain/Posts.java
+++ b/backend/src/main/java/com/trend_now/backend/post/domain/Posts.java
@@ -2,7 +2,7 @@ package com.trend_now.backend.post.domain;
 
 import com.trend_now.backend.board.domain.Boards;
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -47,5 +47,5 @@ public class Posts extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 }

--- a/backend/src/main/java/com/trend_now/backend/post/domain/Scraps.java
+++ b/backend/src/main/java/com/trend_now/backend/post/domain/Scraps.java
@@ -1,7 +1,7 @@
 package com.trend_now.backend.post.domain;
 
 import com.trend_now.backend.config.domain.BaseEntity;
-import com.trend_now.backend.user.domain.Users;
+import com.trend_now.backend.member.domain.Members;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,7 +30,7 @@ public class Scraps extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private Users users;
+    private Members members;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")

--- a/backend/src/main/java/com/trend_now/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/user/repository/UserRepository.java
@@ -1,8 +1,0 @@
-package com.trend_now.backend.user.repository;
-
-
-import com.trend_now.backend.user.domain.Users;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserRepository extends JpaRepository<Users, Long> {
-}


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-15] OAuth2 구글 로그인 구현

## 🔗 관련 이슈
- #14

## ✍️ 변경 사항
- 구글 OAuth2 로그인 개발하였습니다.
- 프론트엔드 화면을 만들어서 다음과 같이 JWT 토큰 발급을 확인했습니다.

![image](https://github.com/user-attachments/assets/125bef13-6a19-47d1-b323-a4f5e5ea6d3d)
![image](https://github.com/user-attachments/assets/ccee5430-93da-4378-97ab-4dc3c900d40f)

백엔드에서의 로그
```2025-03-30T13:25:07.618+09:00  INFO 16960 --- [nio-8080-exec-2] c.t.b.config.auth.JwtTokenProvider       : [JwtTokenProvider.createToken] 생성된 JWT = eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzQzMzA4NzA3LCJleHAiOjE3NDM0ODg3MDd9.nMUHHnFeS-HBYL-7BdGYWu2AP5SsLoYpCVqwZlAMSKF6XBiC8aPIjt-QAIYpgJ5RlBDarDVJIMpgSFwY9rhDXQ```

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 기존의 회원 패키지명이 user 였는데, 비회원 추가 시 혼동이 올 것 같아서 member로 변경하였습니다.
- 현재 구글로만 진행했고, 해당 리뷰 후에 카카오와 네이버도 추가하겠습니다.
- 추가된 파일이 24개 있는데 그 중에서 다음 파일 위주로 보시면 됩니다.
  - SecurityConfig, JwtTokenFilter, JwtTokenProvider, MemberController의 googleLogin 메서드
- 추후 진행으로 다음과 같이 진행하겠습니다.
  - 카카오와 네이버 로그인 추가, Swagger에 security 관련 설정 추가, 비회원 사용 가능 기능들에 대한 uri 패턴을 SecurityConfig 추가

[CCS-18]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CCS-15]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ