### PR TITLE
[fix][CCS-24] 실시간 게시판 리스트 반환 데이터에 게시판 식별자 추가

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -89,7 +89,7 @@ public class BoardRedisService {
                     String boardName = parts[0];
                     Long boardId = Long.parseLong(parts[1]);
 
-                    Long boardLiveTime = redisTemplate.getExpire(boardName, TimeUnit.SECONDS);
+                    Long boardLiveTime = redisTemplate.getExpire(boardKey, TimeUnit.SECONDS);
                     Double score = redisTemplate.opsForZSet().score(BOARD_RANK_KEY, boardKey);
                     return new BoardInfoDto(boardId, boardName, boardLiveTime, score);
                 })

--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -27,10 +27,15 @@ public class BoardRedisService {
     private static final long KEY_LIVE_TIME = 301L;
     private static final int KEY_EXPIRE = 0;
 
+    private static final String BOARD_KEY_DELIMITER  = ":";
+    private static final int BOARD_KEY_PARTS_LENGTH = 2;
+    private static final int BOARD_NAME_INDEX = 0;
+    private static final int BOARD_ID_INDEX = 1;
+
     private final RedisTemplate<String, String> redisTemplate;
 
     public void saveBoardRedis(BoardSaveDto boardSaveDto, int score) {
-        String key = boardSaveDto.getName() + ":" + boardSaveDto.getBoardId();
+        String key = boardSaveDto.getName() + BOARD_KEY_DELIMITER + boardSaveDto.getBoardId();
         long keyLiveTime = KEY_LIVE_TIME;
 
         Long currentExpire = redisTemplate.getExpire(key, TimeUnit.SECONDS);
@@ -80,14 +85,14 @@ public class BoardRedisService {
                 .map(boardKey -> {
 
                     // boardId 추출
-                    String[] parts = boardKey.split(":");
+                    String[] parts = boardKey.split(BOARD_KEY_DELIMITER);
                     log.info("[BoardRedisService.findAllRealTimeBoardPaging] : parts = {}", Arrays.toString(parts));
 
                     // 데이터 타입 이상 시, 다음으로 넘김
-                    if(parts.length < 2) return null;
+                    if(parts.length < BOARD_KEY_PARTS_LENGTH) return null;
 
-                    String boardName = parts[0];
-                    Long boardId = Long.parseLong(parts[1]);
+                    String boardName = parts[BOARD_NAME_INDEX];
+                    Long boardId = Long.parseLong(parts[BOARD_ID_INDEX]);
 
                     Long boardLiveTime = redisTemplate.getExpire(boardKey, TimeUnit.SECONDS);
                     Double score = redisTemplate.opsForZSet().score(BOARD_RANK_KEY, boardKey);

--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
@@ -17,36 +17,32 @@ public class BoardService {
 
     @Transactional
     public Long saveBoardIfNotExists(BoardSaveDto boardSaveDto) {
-        List<Boards> findBoards = boardRepository.findByName(boardSaveDto.getName());
-
-        if (findBoards.isEmpty()) {
-            Boards boards = Boards.builder()
-                    .name(boardSaveDto.getName())
-                    .boardCategory(boardSaveDto.getBoardCategory())
-                    .build();
-
-            boardRepository.save(boards);
-            return boards.getId();
-        }
-
-        return -1L;
+        Boards board = boardRepository.findByName(boardSaveDto.getName())
+                .orElseGet(() -> boardRepository.save(
+                        Boards.builder()
+                                .name(boardSaveDto.getName())
+                                .boardCategory(boardSaveDto.getBoardCategory())
+                                .build()
+                )
+        );
+        return board.getId();
     }
+
 
     @Transactional
     public void updateBoardIsDeleted(BoardSaveDto boardSaveDto, boolean isInRedis) {
-        List<Boards> findBoards = boardRepository.findByName(boardSaveDto.getName());
-        if (findBoards.isEmpty()) {
-            return;
-        }
+        Boards findBoards = boardRepository.findByName(boardSaveDto.getName())
+                .orElseGet(() -> null);
 
-        Boards board = findBoards.getFirst();
+        if(findBoards == null) return;
+
         if(isInRedis) {
-            if(board.isDeleted()) {
-                board.changeDeleted();
+            if(findBoards.isDeleted()) {
+                findBoards.changeDeleted();
             }
         } else {
-            if(!board.isDeleted()) {
-                board.changeDeleted();
+            if(!findBoards.isDeleted()) {
+                findBoards.changeDeleted();
             }
         }
     }

--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
@@ -31,10 +31,11 @@ public class BoardService {
 
     @Transactional
     public void updateBoardIsDeleted(BoardSaveDto boardSaveDto, boolean isInRedis) {
+        // 요구사항을 기반으로 Redis에 있는 게시판 데이터는 DB에도 존재해야 한다.
         Boards findBoards = boardRepository.findByName(boardSaveDto.getName())
-                .orElseGet(() -> null);
-
-        if(findBoards == null) return;
+                .orElseThrow(
+                        () -> new IllegalStateException("해당 게시판이 존재하지 않습니다: " + boardSaveDto.getName())
+                );
 
         if(isInRedis) {
             if(findBoards.isDeleted()) {

--- a/backend/src/main/java/com/trend_now/backend/board/dto/BoardInfoDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/BoardInfoDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class BoardInfoDto {
 
+    private Long boardId;
     private String boardName;
     private long boardLiveTime;
     private double score;

--- a/backend/src/main/java/com/trend_now/backend/board/dto/BoardSaveDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/BoardSaveDto.java
@@ -8,10 +8,11 @@ import lombok.Data;
 @AllArgsConstructor
 public class BoardSaveDto {
 
+    private Long boardId;
     private String name;
     private BoardCategory boardCategory;
 
     public static BoardSaveDto from(Top10 top10) {
-        return new BoardSaveDto(top10.getKeyword(), BoardCategory.REALTIME);
+        return new BoardSaveDto(-1L, top10.getKeyword(), BoardCategory.REALTIME);
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/board/repository/BoardRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/board/repository/BoardRepository.java
@@ -1,10 +1,11 @@
 package com.trend_now.backend.board.repository;
 
 import com.trend_now.backend.board.domain.Boards;
-import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Boards, Long> {
 
-    List<Boards> findByName(String name);
+    Optional<Boards> findByName(String name);
 }

--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -42,8 +42,8 @@ public class SecurityConfig {
                 // 특정 url 패턴에 대해서는 security filter에서 제외(Authentication 객체를 안만들겠다는 의미)
                 // todo. 비회원도 사용 가능한 API의 uri 패턴 추가
                 .authorizeHttpRequests(a -> a.requestMatchers(
-                        "/api/v1/boards/list"
-                                ,"/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**")
+                                "/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/v1/boards/list", "/api/v1/news/realtime",
+                                "/api/v1/timeSync", "/api/v1/subscribe", "/api/v1/unsubscribe", "/sse-test")
                         .permitAll().anyRequest().authenticated())
 
                 /**
@@ -65,7 +65,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));    // 개발 프론트엔드 도메인 허용
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:63342"));    // 개발 프론트엔드 도메인 허용
         configuration.setAllowedMethods(Arrays.asList("*"));    // 모든 HTTP 메서드 허용
         configuration.setAllowedHeaders(Arrays.asList("*"));    // 모든 헤더 값 허용
         configuration.setAllowCredentials(true);    // 자격 증명을 허용(Authorization 헤더를 허용 목적)

--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                 // 특정 url 패턴에 대해서는 security filter에서 제외(Authentication 객체를 안만들겠다는 의미)
                 // todo. 비회원도 사용 가능한 API의 uri 패턴 추가
                 .authorizeHttpRequests(a -> a.requestMatchers(
-                                "/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**")
+                        "/api/v1/boards/list"
+                                ,"/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**")
                         .permitAll().anyRequest().authenticated())
 
                 /**


### PR DESCRIPTION
## 📌 PR 제목
[fix]{CCS-24] 실시간 게시판 리스트 반환 데이터에 게시판 식별자 추가

## 🔗 관련 이슈
- #25 

## ✍️ 변경 사항
- 스케줄러를 실행하면서 boardId 또한 redis에 저장하도록 변경
- 실시간 게시판 리스트 반환 API 호출에 사용되는 서비스 로직에 redis에 저장된 boardId도 같이 반환하도록 변경
<br>

- Swagger를 통한 반환 데이터 확인
```
{
  "boardInfoDtos": [
    {
      "boardId": 8,
      "boardName": "농심",
      "boardLiveTime": 581,
      "score": 8
    },
    {
      "boardId": 9,
      "boardName": "김종민 신혼여행 프랑스",
      "boardLiveTime": 581,
      "score": 9
    },
 ,,,
  ]
}
```

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- SignalKeywordJob 클래스 중 redis에 저장 할 때, boardName과 boardId를 문자열 더하기하여 하나의 문자열로 저장했습니다.
  - 하나의 문자열은 boardName + ":" + boardId로 진행했습니다. ex. "탄핵 선고:1"
  - 이렇게 한 이유는 zset 자료구조에 boardName과 boardId를 따로 저장할려면 JSON 형태로 저장을 해야 한다고 파악했습니다. 해당 과정은 불필요한 과정이며 split(":") 메서드를 통해 간단하게 문자열 파싱이 된다고 생각해 이렇게 진행했습니다.
- BoardRedisService 클래스 중 findAllRealTimeBoardPaging() 메서드에서 redis 데이터 조회 부분을 피드백 부탁드립니다.
- 최대한 기존 코드를 수정하지 않고 진행했습니다.