### PR TITLE
[feat][CCS-34] 실시간 검색어 변동 추이를 계산하여 반환

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordService.java
@@ -81,30 +81,28 @@ public class SignalKeywordService {
             }
         }
 
-        Set<String> currentKeywordSet = new HashSet<>();
-
         for (Top10 currentKeyword : currentKeywordList) {
             String keyword = currentKeyword.getKeyword();
             int currentRank = currentKeyword.getRank();
-            currentKeywordSet.add(keyword);
 
             if (previousRankMap.containsKey(keyword)) {
-                int previousRank = previousRankMap.get(keyword);
+                Integer previousRank = previousRankMap.get(keyword);
                 RankChangeType changeType;
 
-                if (currentRank < previousRank) {
-                    changeType = RankChangeType.UP;
-                } else if (currentRank > previousRank) {
-                    changeType = RankChangeType.DOWN;
+                if (previousRank != null) {
+                    if (currentRank < previousRank) {
+                        changeType = RankChangeType.UP;
+                    } else if (currentRank > previousRank) {
+                        changeType = RankChangeType.DOWN;
+                    } else {
+                        changeType = RankChangeType.SAME;
+                    }
                 } else {
-                    changeType = RankChangeType.SAME;
+                    changeType = RankChangeType.NEW;
                 }
 
                 keywordDiffList.add(
                         new Top10WithDiff(currentRank, keyword, changeType, previousRank));
-            } else {
-                keywordDiffList.add(
-                        new Top10WithDiff(currentRank, keyword, RankChangeType.NEW, null));
             }
         }
 

--- a/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordService.java
@@ -2,7 +2,16 @@ package com.trend_now.backend.board.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trend_now.backend.board.dto.MsgFormat;
+import com.trend_now.backend.board.dto.RankChangeType;
 import com.trend_now.backend.board.dto.SignalKeywordDto;
+import com.trend_now.backend.board.dto.Top10;
+import com.trend_now.backend.board.dto.Top10WithChange;
+import com.trend_now.backend.board.dto.Top10WithDiff;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +33,7 @@ public class SignalKeywordService {
     private static final String JSON_PARSE_ERROR_MESSAGE = "JSON 파싱에 오류가 생겼습니다.";
     private static final String CLIENT_ID_KEY = "clientId";
     private static final String SIGNAL_KEYWORD_LIST_EMITTER_NAME = "signalKeywordList";
+    private static final String SIGNAL_KEYWORD_LIST = "realtime_keywords";
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
@@ -51,6 +61,61 @@ public class SignalKeywordService {
                     }
                 });
     }
+
+    /**
+     * 실시간 검색어 순위 변동 추이를 계산하는 함수이다 Redis에 실시간 검색어 순위가 저장되어 있지 않으면 서버가 처음 시작되었음을 의미하고, 현재 순위를 저장하고 모두
+     * NEW로 처리 이전 순위가 있으면 비교하여 변동 추이를 계산한다
+     */
+    public Top10WithChange calculateRankChange(SignalKeywordDto signalKeywordDto) {
+        long now = signalKeywordDto.getNow();
+        List<Top10> currentKeywordList = signalKeywordDto.getTop10();
+        List<Top10WithDiff> keywordDiffList = new ArrayList<>();
+
+        List<String> previousKeywordList = redisTemplate.opsForList()
+                .range(SIGNAL_KEYWORD_LIST, 0, -1);
+
+        Map<String, Integer> previousRankMap = new HashMap<>();
+        if (previousKeywordList != null) {
+            for (int i = 0; i < previousKeywordList.size(); i++) {
+                previousRankMap.put(previousKeywordList.get(i), i + 1);
+            }
+        }
+
+        Set<String> currentKeywordSet = new HashSet<>();
+
+        for (Top10 currentKeyword : currentKeywordList) {
+            String keyword = currentKeyword.getKeyword();
+            int currentRank = currentKeyword.getRank();
+            currentKeywordSet.add(keyword);
+
+            if (previousRankMap.containsKey(keyword)) {
+                int previousRank = previousRankMap.get(keyword);
+                RankChangeType changeType;
+
+                if (currentRank < previousRank) {
+                    changeType = RankChangeType.UP;
+                } else if (currentRank > previousRank) {
+                    changeType = RankChangeType.DOWN;
+                } else {
+                    changeType = RankChangeType.SAME;
+                }
+
+                keywordDiffList.add(
+                        new Top10WithDiff(currentRank, keyword, changeType, previousRank));
+            } else {
+                keywordDiffList.add(
+                        new Top10WithDiff(currentRank, keyword, RankChangeType.NEW, null));
+            }
+        }
+
+        redisTemplate.delete(SIGNAL_KEYWORD_LIST);
+        currentKeywordList.forEach(keyword ->
+                redisTemplate.opsForList().rightPush(SIGNAL_KEYWORD_LIST, keyword.getKeyword())
+        );
+
+        return new Top10WithChange(now, keywordDiffList);
+    }
+
 
     private void saveClientId(String clientId) {
         redisTemplate.opsForSet().add(CLIENT_ID_KEY, clientId);

--- a/backend/src/main/java/com/trend_now/backend/board/application/SseEmitterService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/SseEmitterService.java
@@ -9,8 +9,8 @@
 package com.trend_now.backend.board.application;
 
 import com.trend_now.backend.board.dto.RealTimeBoardKeyExpiredEvent;
-import com.trend_now.backend.board.dto.SignalKeywordDto;
 import com.trend_now.backend.board.dto.SignalKeywordEventDto;
+import com.trend_now.backend.board.dto.Top10WithChange;
 import com.trend_now.backend.board.repository.SseEmitterRepository;
 import java.io.IOException;
 import java.util.Set;
@@ -43,11 +43,11 @@ public class SseEmitterService {
     }
 
     public void sendKeywordList(SignalKeywordEventDto event) {
-        SignalKeywordDto signalKeywordDto = event.getSignalKeywordDto();
+        Top10WithChange top10WithChange = event.getTop10WithChange();
         String clientId = event.getClientId();
 
         sseEmitterRepository.findById(clientId)
-                .ifPresent(sseEmitter -> send(signalKeywordDto, SIGNAL_KEYWORD_LIST_EMITTER_NAME,
+                .ifPresent(sseEmitter -> send(top10WithChange, SIGNAL_KEYWORD_LIST_EMITTER_NAME,
                         clientId, sseEmitter));
     }
 

--- a/backend/src/main/java/com/trend_now/backend/board/dto/RankChangeType.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/RankChangeType.java
@@ -1,0 +1,8 @@
+package com.trend_now.backend.board.dto;
+
+/**
+ * UP : 이전 순위보다 올라감 DOWN : 이전 순위보다 내려감 SAME : 이전 순위랑 동일 NEW : 이전 순위에 없었음
+ */
+public enum RankChangeType {
+    UP, DOWN, SAME, NEW
+}

--- a/backend/src/main/java/com/trend_now/backend/board/dto/SignalKeywordEventDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/SignalKeywordEventDto.java
@@ -13,5 +13,5 @@ public class SignalKeywordEventDto {
 
     private String clientId;
     private String message;
-    private SignalKeywordDto signalKeywordDto;
+    private Top10WithChange top10WithChange;
 }

--- a/backend/src/main/java/com/trend_now/backend/board/dto/Top10WithChange.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/Top10WithChange.java
@@ -1,0 +1,13 @@
+package com.trend_now.backend.board.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Top10WithChange {
+
+    private long now;
+    private List<Top10WithDiff> top10WithDiff;
+}

--- a/backend/src/main/java/com/trend_now/backend/board/dto/Top10WithDiff.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/Top10WithDiff.java
@@ -1,0 +1,14 @@
+package com.trend_now.backend.board.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Top10WithDiff {
+
+    private int rank;
+    private String keyword;
+    private RankChangeType rankChangeType;
+    private Integer previousRank;
+}


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-34] 실시간 검색어 변동 추이를 계산하여 반환

## 🔗 관련 이슈
- #42 

## ✍️ 변경 사항
- 실시간 검색어 순위를 반환할 때 이전의 검색어 순위와 비교하여 검색어의 순위가 어떻게 변경되었는지 포함하였습니다.
- SignalKeywordJob에서 SignalKeywordDto를 SSE로 사용자에게 전달하였는데, 이것을 Top10WithChange로 변경하였습니다.
- Top10WithChange는 현재 시간과 Top10WithDiff를 포함하고, Top10WithDiff는 현재 순위, 검색어, 검색어 순위 변경 문자열, 이전 순위를 포함합니다.

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 혹시라도 로컬 Redis에서 오류가 발생할 수도 있습니다. 이는 opsForList()에 left push와 right push를 할 때 발생되는 오류일 수도 있기 때문에 Redis의 설정을 변경하시거나 서버를 다시 실행하시면 됩니다.
- SignalKeywordService의 calculateRankChange()에서 순위를 비교하기 위해 Map과 Set을 사용한 것에 대해 어떻게 생각하시나요? 검색어가 10개 뿐이라 List를 사용해도 크게 시간 차이는 없다고 생각하지만, 최적의 자료구조는 아니라고 생각했었습니다.

[CCS-34]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ