### PR TITLE
[feat][CCS-44] 사용자 메인 페이지 접속 호출 API 구성

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**",
                     "/api/v1/news/realtime", "/api/v1/timeSync", "/api/v1/subscribe",
-                    "/api/v1/unsubscribe", "/sse-test", "/api/v1/member/test-jwt", "/api/v1/loadMainNotLogin").permitAll()
+                    "/api/v1/unsubscribe", "/sse-test", "/api/v1/member/test-jwt", "/api/v1/loadMain").permitAll()
                 .anyRequest().authenticated())
 
             /**

--- a/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/trend_now/backend/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/v1/member/login/**", "/swagger-ui/**", "/v3/api-docs/**",
                     "/api/v1/news/realtime", "/api/v1/timeSync", "/api/v1/subscribe",
-                    "/api/v1/unsubscribe", "/sse-test", "/api/v1/member/test-jwt").permitAll()
+                    "/api/v1/unsubscribe", "/sse-test", "/api/v1/member/test-jwt", "/api/v1/loadMainNotLogin").permitAll()
                 .anyRequest().authenticated())
 
             /**

--- a/backend/src/main/java/com/trend_now/backend/main/dto/MainPageDto.java
+++ b/backend/src/main/java/com/trend_now/backend/main/dto/MainPageDto.java
@@ -1,0 +1,19 @@
+package com.trend_now.backend.main.dto;
+
+import com.trend_now.backend.board.dto.BoardPagingResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MainPageDto {
+
+    private String memberName;
+    private String boardRankValidTime;
+    private BoardPagingResponseDto boardPagingResponseDto;
+
+    public static MainPageDto of(String memberName, String boardRankValidTime,
+            BoardPagingResponseDto boardPagingResponseDto) {
+        return new MainPageDto(memberName, boardRankValidTime, boardPagingResponseDto);
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/main/presentation/MainPageController.java
+++ b/backend/src/main/java/com/trend_now/backend/main/presentation/MainPageController.java
@@ -3,14 +3,18 @@ package com.trend_now.backend.main.presentation;
 import com.trend_now.backend.board.application.BoardRedisService;
 import com.trend_now.backend.board.dto.BoardPagingRequestDto;
 import com.trend_now.backend.board.dto.BoardPagingResponseDto;
+import com.trend_now.backend.config.auth.CustomUserDetails;
 import com.trend_now.backend.main.dto.MainPageDto;
 import com.trend_now.backend.member.domain.Members;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,10 +35,7 @@ public class MainPageController {
 
     @GetMapping("/loadMain")
     @Operation(summary = "로그인 사용자 메인 페이지 로드", description = "로그인한 사용자가 서비스에 처음 접근하였을 때 호출하는 API입니다.")
-    public ResponseEntity<MainPageDto> loadMainPage(
-            @AuthenticationPrincipal(expression = "members") Members members) {
-
-        log.info("로그인한 사용자가 메인 페이지를 로드하였습니다.");
+    public ResponseEntity<MainPageDto> loadMainPage(Authentication authentication) {
 
         BoardPagingRequestDto boardPagingRequestDto = new BoardPagingRequestDto(FIRST_PAGE,
                 FIRST_PAGE_SIZE);
@@ -42,27 +43,23 @@ public class MainPageController {
                 boardPagingRequestDto);
         String boardRankValidTime = boardRedisService.getBoardRankValidTime();
 
-        MainPageDto mainPageDto = MainPageDto.of(members.getName(), boardRankValidTime,
-                allRealTimeBoardPaging);
+        log.info("Authentication: {}", authentication);
 
-        return ResponseEntity.status(HttpStatus.OK).body(mainPageDto);
-    }
+        String name;
 
-    @GetMapping("/loadMainNotLogin")
-    @Operation(summary = "로그인하지 않은 사용자 메인 페이지 로드", description = "로그인하지 않은 사용자가 서비스에 처음 접근하였을 때 호출하는 API입니다.")
-    public ResponseEntity<MainPageDto> loadMainPageNotLogin() {
+        if(authentication != null && authentication.isAuthenticated() && !(authentication instanceof AnonymousAuthenticationToken)) {
+            //Members members = (Members) authentication.getPrincipal();
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            Members members = userDetails.getMembers();
+            log.info("로그인한 사용자가 메인 페이지를 로드하였습니다.");
+            name = members.getName();
+        } else {
+            log.info("로그인하지 않은 사용자가 메인 페이지를 로드하였습니다.");
+            name = NOT_LOGIN_MEMBER_NAME;
+        }
 
-        log.info("로그인하지 않은 사용자가 메인 페이지를 로드하였습니다.");
-
-        BoardPagingRequestDto boardPagingRequestDto = new BoardPagingRequestDto(FIRST_PAGE,
-                FIRST_PAGE_SIZE);
-        BoardPagingResponseDto allRealTimeBoardPaging = boardRedisService.findAllRealTimeBoardPaging(
-                boardPagingRequestDto);
-        String boardRankValidTime = boardRedisService.getBoardRankValidTime();
-
-        MainPageDto mainPageDto = MainPageDto.of(NOT_LOGIN_MEMBER_NAME, boardRankValidTime,
-                allRealTimeBoardPaging);
-
-        return ResponseEntity.status(HttpStatus.OK).body(mainPageDto);
+        // inline으로 객체 반환
+        return ResponseEntity.status(HttpStatus.OK).body(
+                MainPageDto.of(name, boardRankValidTime,allRealTimeBoardPaging));
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/main/presentation/MainPageController.java
+++ b/backend/src/main/java/com/trend_now/backend/main/presentation/MainPageController.java
@@ -1,0 +1,68 @@
+package com.trend_now.backend.main.presentation;
+
+import com.trend_now.backend.board.application.BoardRedisService;
+import com.trend_now.backend.board.dto.BoardPagingRequestDto;
+import com.trend_now.backend.board.dto.BoardPagingResponseDto;
+import com.trend_now.backend.main.dto.MainPageDto;
+import com.trend_now.backend.member.domain.Members;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "메인 페이지", description = "메인 페이지 API")
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1")
+public class MainPageController {
+
+    private static final String NOT_LOGIN_MEMBER_NAME = "Guest";
+    private static final int FIRST_PAGE = 0;
+    private static final int FIRST_PAGE_SIZE = 10;
+
+    private final BoardRedisService boardRedisService;
+
+    @GetMapping("/loadMain")
+    @Operation(summary = "로그인 사용자 메인 페이지 로드", description = "로그인한 사용자가 서비스에 처음 접근하였을 때 호출하는 API입니다.")
+    public ResponseEntity<MainPageDto> loadMainPage(
+            @AuthenticationPrincipal(expression = "members") Members members) {
+
+        log.info("로그인한 사용자가 메인 페이지를 로드하였습니다.");
+
+        BoardPagingRequestDto boardPagingRequestDto = new BoardPagingRequestDto(FIRST_PAGE,
+                FIRST_PAGE_SIZE);
+        BoardPagingResponseDto allRealTimeBoardPaging = boardRedisService.findAllRealTimeBoardPaging(
+                boardPagingRequestDto);
+        String boardRankValidTime = boardRedisService.getBoardRankValidTime();
+
+        MainPageDto mainPageDto = MainPageDto.of(members.getName(), boardRankValidTime,
+                allRealTimeBoardPaging);
+
+        return ResponseEntity.status(HttpStatus.OK).body(mainPageDto);
+    }
+
+    @GetMapping("/loadMainNotLogin")
+    @Operation(summary = "로그인하지 않은 사용자 메인 페이지 로드", description = "로그인하지 않은 사용자가 서비스에 처음 접근하였을 때 호출하는 API입니다.")
+    public ResponseEntity<MainPageDto> loadMainPageNotLogin() {
+
+        log.info("로그인하지 않은 사용자가 메인 페이지를 로드하였습니다.");
+
+        BoardPagingRequestDto boardPagingRequestDto = new BoardPagingRequestDto(FIRST_PAGE,
+                FIRST_PAGE_SIZE);
+        BoardPagingResponseDto allRealTimeBoardPaging = boardRedisService.findAllRealTimeBoardPaging(
+                boardPagingRequestDto);
+        String boardRankValidTime = boardRedisService.getBoardRankValidTime();
+
+        MainPageDto mainPageDto = MainPageDto.of(NOT_LOGIN_MEMBER_NAME, boardRankValidTime,
+                allRealTimeBoardPaging);
+
+        return ResponseEntity.status(HttpStatus.OK).body(mainPageDto);
+    }
+}

--- a/backend/src/test/java/com/trend_now/backend/main/controller/MainPageControllerTest.java
+++ b/backend/src/test/java/com/trend_now/backend/main/controller/MainPageControllerTest.java
@@ -1,0 +1,112 @@
+package com.trend_now.backend.main.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.trend_now.backend.annotation.WithMockCustomUser;
+import com.trend_now.backend.board.application.BoardRedisService;
+import com.trend_now.backend.board.application.BoardService;
+import com.trend_now.backend.board.domain.BoardCategory;
+import com.trend_now.backend.board.domain.Boards;
+import com.trend_now.backend.board.dto.BoardSaveDto;
+import com.trend_now.backend.board.dto.Top10;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class MainPageControllerTest {
+
+    private static final int BOARD_COUNT = 20;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BoardRedisService boardRedisService;
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private List<Boards> boards;
+    private List<Top10> top10s;
+
+    @BeforeEach
+    public void beforeEach() {
+        //실시간 검색어 순위 게시판 Setting
+        boards = new ArrayList<>();
+        top10s = new ArrayList<>();
+        for (int i = 0; i < BOARD_COUNT; i++) {
+            Boards boards = Boards.builder()
+                    .name("B" + i)
+                    .boardCategory(BoardCategory.REALTIME)
+                    .build();
+            Top10 top10 = new Top10(i, "B" + i);
+            this.boards.add(boards);
+            this.top10s.add(top10);
+        }
+
+        redisTemplate.getConnectionFactory().getConnection().flushDb();
+        for (int i = 0; i < BOARD_COUNT; i++) {
+            BoardSaveDto boardSaveDto = BoardSaveDto.from(top10s.get(i));
+            Long boardId = boardService.saveBoardIfNotExists(boardSaveDto);
+            boardSaveDto.setBoardId(boardId);
+            boardRedisService.saveBoardRedis(boardSaveDto, i);
+        }
+
+        //현재 시간 Setting
+        boardRedisService.setRankValidListTime();
+    }
+
+    @WithMockCustomUser
+    @Test
+    @DisplayName("로그인된 사용자는 메인 페이지에 접속하였을 때 필요한 정보를 받을 수 있다")
+    public void 로그인_사용자_메인페이지_접속() throws Exception {
+        //given
+
+        //when
+
+        //then
+        mockMvc.perform(get("/api/v1/loadMain"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberName").value("testUser"))
+                .andDo(print());
+    }
+
+    @WithAnonymousUser
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 메인 페이지에 접속하였을 때 회원 이름을 제외한 정보를 받을 수 있다")
+    public void 비로그인_사용자_메인페이지_접속() throws Exception {
+        //given
+
+        //when
+
+        //then
+        mockMvc.perform(get("/api/v1/loadMainNotLogin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberName").value("Guest"))
+                .andDo(print());
+    }
+
+}

--- a/backend/src/test/java/com/trend_now/backend/main/controller/MainPageControllerTest.java
+++ b/backend/src/test/java/com/trend_now/backend/main/controller/MainPageControllerTest.java
@@ -103,7 +103,7 @@ public class MainPageControllerTest {
         //when
 
         //then
-        mockMvc.perform(get("/api/v1/loadMainNotLogin"))
+        mockMvc.perform(get("/api/v1/loadMain"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.memberName").value("Guest"))
                 .andDo(print());


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-44] 사용자 메인 페이지 접속 호출 API 구성

## 🔗 관련 이슈
- #53 

## ✍️ 변경 사항
- 사용자가 메인 페이지에 접속하였을 때 로그인 유무에 따라 서로 다른 정보를 하나의 API로 반환받습니다.

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 현재 컨트롤러를 로그인 유무에 따라 메소드를 두 개 생성했는데, 하나로 합치는 게 좋을까요? 합치는 게 좋다면 파라미터는 어떻게 하면 좋을까요?

[CCS-44]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ