### PR TITLE
[feat][CCS-46] 마이페이지 정보 조회 기능 추가 및 수정

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
@@ -17,6 +17,7 @@ import com.trend_now.backend.post.repository.PostsRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -140,13 +141,8 @@ public class CommentsService {
                 ? BoardTtlStatus.BOARD_TTL_BEFORE : BoardTtlStatus.BOARD_TTL_AFTER;
     }
 
-    public CommentListPagingResponseDto getCommentsByMemberId(Long memberId, int page, int size) {
+    public Page<CommentInfoDto> getCommentsByMemberId(Long memberId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<CommentInfoDto> commentInfoPages = commentsRepository.findByMemberIdWithPost(memberId, pageable);
-        return CommentListPagingResponseDto.builder()
-            .message("댓글 목록 조회 성공")
-            .totalPageCount(commentInfoPages.getTotalPages())
-            .commentsInfoListDto(commentInfoPages.getContent())
-            .build();
+        return commentsRepository.findByMemberIdWithPost(memberId, pageable);
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
@@ -1,5 +1,7 @@
 package com.trend_now.backend.comment.application;
 
+import com.trend_now.backend.comment.data.dto.CommentInfoDto;
+import com.trend_now.backend.comment.data.dto.CommentListPagingResponseDto;
 import com.trend_now.backend.comment.data.dto.DeleteCommentsDto;
 import com.trend_now.backend.comment.data.dto.SaveCommentsDto;
 import com.trend_now.backend.comment.data.dto.UpdateCommentsDto;
@@ -12,7 +14,12 @@ import com.trend_now.backend.exception.CustomException.NotFoundException;
 import com.trend_now.backend.member.domain.Members;
 import com.trend_now.backend.post.domain.Posts;
 import com.trend_now.backend.post.repository.PostsRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -131,5 +138,15 @@ public class CommentsService {
         String key = boardName + BOARD_KEY_DELIMITER + boardId;
         return redisTemplate.hasKey(key)
                 ? BoardTtlStatus.BOARD_TTL_BEFORE : BoardTtlStatus.BOARD_TTL_AFTER;
+    }
+
+    public CommentListPagingResponseDto getCommentsByMemberId(Long memberId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<CommentInfoDto> commentInfoPages = commentsRepository.findByMemberIdWithPost(memberId, pageable);
+        return CommentListPagingResponseDto.builder()
+            .message("댓글 목록 조회 성공")
+            .totalPageCount(commentInfoPages.getTotalPages())
+            .commentsInfoListDto(commentInfoPages.getContent())
+            .build();
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentInfoDto.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentInfoDto.java
@@ -1,0 +1,19 @@
+package com.trend_now.backend.comment.data.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentInfoDto {
+    private Long postId;
+    private String postTitle;
+    private Long commentId;
+    private String content;
+    private String nickname;
+    //    private int likeCount;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentListPagingResponseDto.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentListPagingResponseDto.java
@@ -1,0 +1,15 @@
+package com.trend_now.backend.comment.data.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CommentListPagingResponseDto {
+    private String message;
+    private int totalPageCount;
+    private List<CommentInfoDto> commentsInfoListDto;
+}

--- a/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentListPagingResponseDto.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/data/dto/CommentListPagingResponseDto.java
@@ -2,14 +2,16 @@ package com.trend_now.backend.comment.data.dto;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Builder
 public class CommentListPagingResponseDto {
     private String message;
     private int totalPageCount;
     private List<CommentInfoDto> commentsInfoListDto;
+
+    public static CommentListPagingResponseDto of(String message, int totalPageCount, List<CommentInfoDto> commentsInfoListDto) {
+        return new CommentListPagingResponseDto(message, totalPageCount, commentsInfoListDto);
+    }
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
@@ -53,4 +53,6 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
             """
     )
     Page<CommentInfoDto> findByMemberIdWithPost(@Param("memberId") Long membersId, Pageable pageable);
+
+    void deleteByPosts_Id(Long postsId);
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
@@ -1,8 +1,11 @@
 package com.trend_now.backend.comment.repository;
 
+import com.trend_now.backend.comment.data.dto.CommentInfoDto;
 import com.trend_now.backend.comment.data.dto.FindAllCommentsDto;
 import com.trend_now.backend.comment.domain.Comments;
 import com.trend_now.backend.member.domain.Members;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,22 +18,39 @@ import java.util.Optional;
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     /**
-     * JPQL을 이용한 프로젝션 처리 방식
-     * - DTO 생성자의 파라미터 순서와 SELECT 순서를 지켜줘야 한다.
-     * - DTO 객체로 쿼리 결과를 반환하기 위해선 SELECT 부분에 new 키워드와 해당 DTO 경로를 지정해줘야 한다.
+     * JPQL을 이용한 프로젝션 처리 방식 - DTO 생성자의 파라미터 순서와 SELECT 순서를 지켜줘야 한다. - DTO 객체로 쿼리 결과를 반환하기 위해선 SELECT
+     * 부분에 new 키워드와 해당 DTO 경로를 지정해줘야 한다.
      */
     @Query("""
-            SELECT new com.trend_now.backend.comment.data.dto.FindAllCommentsDto(
-                   c.createdAt, c.updatedAt, c.id, c.content, c.boardTtlStatus
-                )
-            FROM Comments c
-            WHERE c.posts.id = :postId
-            ORDER BY c.createdAt DESC
-            """)
+        SELECT new com.trend_now.backend.comment.data.dto.FindAllCommentsDto(
+               c.createdAt, c.updatedAt, c.id, c.content, c.boardTtlStatus
+            )
+        FROM Comments c
+        WHERE c.posts.id = :postId
+        ORDER BY c.createdAt DESC
+        """)
     List<FindAllCommentsDto> findByPostsIdOrderByCreatedAtDesc(
-            @Param("postId") Long postId);
+        @Param("postId") Long postId);
 
     void deleteByIdAndMembers(Long commentId, Members members);
 
     Optional<Comments> findByIdAndMembers(Long commentId, Members members);
+
+    @Query(
+        value = """
+        SELECT new com.trend_now.backend.comment.data.dto.CommentInfoDto(
+              p.id, p.title, c.id, c.content, m.name, c.createdAt
+            )
+        FROM Comments c
+        JOIN c.posts p
+        JOIN c.members m
+        WHERE c.members.id = :memberId
+        """,
+        countQuery = """
+            SELECT COUNT(c)
+            FROM Comments c
+            WHERE c.members.id = :memberId
+            """
+    )
+    Page<CommentInfoDto> findByMemberIdWithPost(@Param("memberId") Long membersId, Pageable pageable);
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/repository/CommentsRepository.java
@@ -18,8 +18,12 @@ import java.util.Optional;
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     /**
-     * JPQL을 이용한 프로젝션 처리 방식 - DTO 생성자의 파라미터 순서와 SELECT 순서를 지켜줘야 한다. - DTO 객체로 쿼리 결과를 반환하기 위해선 SELECT
-     * 부분에 new 키워드와 해당 DTO 경로를 지정해줘야 한다.
+     * <pre>
+     * JPQL을 이용한 프로젝션 처리 방식\
+     *
+     * - DTO 생성자의 파라미터 순서와 SELECT 순서를 지켜줘야 한다.
+     * - DTO 객체로 쿼리 결과를 반환하기 위해선 SELECT 부분에 new 키워드와 해당 DTO 경로를 지정해줘야 한다.
+     * </pre>
      */
     @Query("""
         SELECT new com.trend_now.backend.comment.data.dto.FindAllCommentsDto(
@@ -38,21 +42,22 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     @Query(
         value = """
-        SELECT new com.trend_now.backend.comment.data.dto.CommentInfoDto(
-              p.id, p.title, c.id, c.content, m.name, c.createdAt
-            )
-        FROM Comments c
-        JOIN c.posts p
-        JOIN c.members m
-        WHERE c.members.id = :memberId
-        """,
+            SELECT new com.trend_now.backend.comment.data.dto.CommentInfoDto(
+                  p.id, p.title, c.id, c.content, m.name, c.createdAt
+                )
+            FROM Comments c
+            JOIN c.posts p
+            JOIN c.members m
+            WHERE c.members.id = :memberId
+            """,
         countQuery = """
             SELECT COUNT(c)
             FROM Comments c
             WHERE c.members.id = :memberId
             """
     )
-    Page<CommentInfoDto> findByMemberIdWithPost(@Param("memberId") Long membersId, Pageable pageable);
+    Page<CommentInfoDto> findByMemberIdWithPost(@Param("memberId") Long membersId,
+        Pageable pageable);
 
     void deleteByPosts_Id(Long postsId);
 }

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.trend_now.backend.member.application;
 import com.trend_now.backend.config.auth.JwtTokenProvider;
 import com.trend_now.backend.exception.CustomException.DuplicateException;
 import com.trend_now.backend.exception.CustomException.NotFoundException;
+import com.trend_now.backend.member.data.dto.MyPageResponseDto;
 import com.trend_now.backend.member.data.vo.GoogleProfile;
 import com.trend_now.backend.member.data.vo.KakaoProfile;
 import com.trend_now.backend.member.data.vo.NaverProfile;
@@ -71,6 +72,13 @@ public class MemberService {
 
         memberRepository.save(member);
         return member;
+    }
+
+    /**
+     * 마이페이지 조회
+     */
+    public MyPageResponseDto getMyPage(Members members) {
+        return MyPageResponseDto.of(members.getName(), members.getEmail());
     }
 
     /**

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -14,7 +14,6 @@ import com.trend_now.backend.post.repository.PostsRepository;
 import com.trend_now.backend.post.repository.ScrapRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +30,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PostsRepository postsRepository;
-    private final PasswordEncoder passwordEncoder;
     private final ScrapRepository scrapRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -77,7 +75,9 @@ public class MemberService {
     /**
      * 마이페이지 조회
      */
-    public MyPageResponseDto getMyPage(Members members) {
+    public MyPageResponseDto getMyPage(Long memberId) {
+        Members members = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotFoundException(NOT_EXIST_MEMBER));
         return MyPageResponseDto.of(members.getName(), members.getEmail());
     }
 

--- a/backend/src/main/java/com/trend_now/backend/member/data/dto/MyPageResponseDto.java
+++ b/backend/src/main/java/com/trend_now/backend/member/data/dto/MyPageResponseDto.java
@@ -1,0 +1,15 @@
+package com.trend_now.backend.member.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyPageResponseDto {
+    private String nickname;
+    private String email;
+
+    public static MyPageResponseDto of(String nickname, String email) {
+        return new MyPageResponseDto(nickname, email);
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -4,6 +4,7 @@ import com.trend_now.backend.member.application.GoogleService;
 import com.trend_now.backend.member.application.KakaoService;
 import com.trend_now.backend.member.application.MemberService;
 import com.trend_now.backend.member.application.NaverService;
+import com.trend_now.backend.member.data.dto.MyPageResponseDto;
 import com.trend_now.backend.member.data.dto.UpdateNicknameRequestDto;
 import com.trend_now.backend.member.data.vo.AuthCodeToJwtRequest;
 import com.trend_now.backend.member.data.vo.OAuth2LoginResponse;
@@ -87,6 +88,16 @@ public class MemberController {
     @PostMapping("/login/test/naver")
     public ResponseEntity<OAuth2LoginResponse> testNaverLogin(@RequestBody AuthCodeToJwtRequest accessToken) {
         return new ResponseEntity<>(naverService.testGetToken(accessToken), HttpStatus.OK);
+    }
+
+    /**
+     * 마이페이지 조회 API
+     */
+    @GetMapping("/me")
+    public ResponseEntity<MyPageResponseDto> getMyPage(
+        @AuthenticationPrincipal(expression = "members") Members member) {
+        MyPageResponseDto myPageResponseDto = memberService.getMyPage(member);
+        return new ResponseEntity<>(myPageResponseDto, HttpStatus.OK);
     }
 
     /**

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -1,5 +1,7 @@
 package com.trend_now.backend.member.presentation;
 
+import com.trend_now.backend.comment.application.CommentsService;
+import com.trend_now.backend.comment.data.dto.CommentListPagingResponseDto;
 import com.trend_now.backend.member.application.GoogleService;
 import com.trend_now.backend.member.application.KakaoService;
 import com.trend_now.backend.member.application.MemberService;
@@ -44,6 +46,7 @@ public class MemberController {
     private static final String WITHDRAWAL_SUCCESS_MESSAGE = "회원 탈퇴가 완료";
     private static final String FIND_SCRAP_POSTS_SUCCESS_MESSAGE = "사용자가 스크랩한 게시글 조회 완료";
     private static final String FIND_MEMBER_POSTS_SUCCESS_MESSAGE = "사용자가 작성한 게시글 조회 완료";
+    private final CommentsService commentsService;
 
     // 연결 확인
     @GetMapping("")
@@ -60,25 +63,25 @@ public class MemberController {
     }
 
     /**
-     *  구글 인가코드를 받는 Controller
-     *  - 프론트엔드에서 구글 인가코드를 가지고 유저 정보를 반환받는 Controller
-     *  - 해당 Controller에서 HTTP Body를 통해 인가 코드를 받음
-     *  - 해당 인가 코드를 가지고 구글 서버에 사용자 정보 요청
-     *  - 사용자 정보를 통해 서비스 유저인지 확인
-     *  - 유저인 경우, JWT 토큰 발급
+     * 구글 인가코드를 받는 Controller - 프론트엔드에서 구글 인가코드를 가지고 유저 정보를 반환받는 Controller - 해당 Controller에서 HTTP
+     * Body를 통해 인가 코드를 받음 - 해당 인가 코드를 가지고 구글 서버에 사용자 정보 요청 - 사용자 정보를 통해 서비스 유저인지 확인 - 유저인 경우, JWT 토큰
+     * 발급
      */
     @PostMapping("/login/google")
-    public ResponseEntity<OAuth2LoginResponse> googleLogin(@RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
+    public ResponseEntity<OAuth2LoginResponse> googleLogin(
+        @RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
         return new ResponseEntity<>(googleService.getToken(authCodeToJwtRequest), HttpStatus.OK);
     }
 
     @PostMapping("/login/kakao")
-    public ResponseEntity<OAuth2LoginResponse> kakaoLogin(@RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
+    public ResponseEntity<OAuth2LoginResponse> kakaoLogin(
+        @RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
         return new ResponseEntity<>(kakaoService.getToken(authCodeToJwtRequest), HttpStatus.OK);
     }
 
     @PostMapping("/login/naver")
-    public ResponseEntity<OAuth2LoginResponse> naverLogin(@RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
+    public ResponseEntity<OAuth2LoginResponse> naverLogin(
+        @RequestBody AuthCodeToJwtRequest authCodeToJwtRequest) {
         return new ResponseEntity<>(naverService.getToken(authCodeToJwtRequest), HttpStatus.OK);
     }
 
@@ -86,7 +89,8 @@ public class MemberController {
      * Postman 테스트용 API
      */
     @PostMapping("/login/test/naver")
-    public ResponseEntity<OAuth2LoginResponse> testNaverLogin(@RequestBody AuthCodeToJwtRequest accessToken) {
+    public ResponseEntity<OAuth2LoginResponse> testNaverLogin(
+        @RequestBody AuthCodeToJwtRequest accessToken) {
         return new ResponseEntity<>(naverService.testGetToken(accessToken), HttpStatus.OK);
     }
 
@@ -94,14 +98,15 @@ public class MemberController {
      * 마이페이지 조회 API
      */
     @GetMapping("/me")
+    @Operation(summary = "마이페이지 조회", description = "회원의 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MyPageResponseDto> getMyPage(
         @AuthenticationPrincipal(expression = "members") Members member) {
-        MyPageResponseDto myPageResponseDto = memberService.getMyPage(member);
+        MyPageResponseDto myPageResponseDto = memberService.getMyPage(member.getId());
         return new ResponseEntity<>(myPageResponseDto, HttpStatus.OK);
     }
 
     /**
-     *  닉네임 변경 API
+     * 닉네임 변경 API
      */
     @PatchMapping("/nickname")
     @Operation(summary = "닉네임 변경", description = "닉네임 변경을 요청한 사용자의 닉네임을 변경합니다.")
@@ -113,12 +118,12 @@ public class MemberController {
     }
 
     /**
-     * 회원 탈퇴 API
-     * API가 호출되면 해당 회원의 값을 DB에서 물리적으로 삭제함
+     * 회원 탈퇴 API API가 호출되면 해당 회원의 값을 DB에서 물리적으로 삭제함
      */
     @DeleteMapping("/withdrawal")
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 요청한 사용자의 정보를 삭제합니다. 해당 사용자가 작성한 글의 작성자는 NULL로 변경됩니다.")
-    public ResponseEntity<String> withdrawMember(@AuthenticationPrincipal(expression = "members") Members member) {
+    public ResponseEntity<String> withdrawMember(
+        @AuthenticationPrincipal(expression = "members") Members member) {
         memberService.deleteMember(member.getId());
         return new ResponseEntity<>(WITHDRAWAL_SUCCESS_MESSAGE, HttpStatus.NO_CONTENT);
     }
@@ -136,7 +141,8 @@ public class MemberController {
         List<PostSummaryDto> scrappedPostsByMemberId = scrapService.getScrappedPostsByMemberId(
             member.getId(), page, size);
         return new ResponseEntity<>(
-            PostListPagingResponseDto.of(FIND_SCRAP_POSTS_SUCCESS_MESSAGE, scrappedPostsByMemberId), HttpStatus.OK);
+            PostListPagingResponseDto.of(FIND_SCRAP_POSTS_SUCCESS_MESSAGE, scrappedPostsByMemberId),
+            HttpStatus.OK);
     }
 
     /**
@@ -151,6 +157,16 @@ public class MemberController {
         List<PostSummaryDto> postsByMemberId = postsService.getPostsByMemberId(member.getId(), page,
             size);
         return new ResponseEntity<>(
-            PostListPagingResponseDto.of(FIND_MEMBER_POSTS_SUCCESS_MESSAGE, postsByMemberId), HttpStatus.OK);
+            PostListPagingResponseDto.of(FIND_MEMBER_POSTS_SUCCESS_MESSAGE, postsByMemberId),
+            HttpStatus.OK);
+    }
+
+    @GetMapping("/comments")
+    @Operation(summary = "회원이 작성한 댓글 목록 조회", description = "회원이 작성한 댓글을 조회합니다.")
+    public ResponseEntity<CommentListPagingResponseDto> getMemberComments(
+        @AuthenticationPrincipal(expression = "members") Members member,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size) {
+        return new ResponseEntity<>(commentsService.getCommentsByMemberId(member.getId(), page, size), HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/post/application/PostsService.java
+++ b/backend/src/main/java/com/trend_now/backend/post/application/PostsService.java
@@ -18,8 +18,6 @@ import com.trend_now.backend.post.dto.PostsInfoDto;
 import com.trend_now.backend.post.dto.PostsPagingRequestDto;
 import com.trend_now.backend.post.dto.PostsSaveDto;
 import com.trend_now.backend.post.dto.PostsUpdateRequestDto;
-import com.trend_now.backend.post.presentation.BoardTtlException;
-import com.trend_now.backend.post.presentation.BoardTtlStatus;
 import com.trend_now.backend.post.repository.PostsRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -159,5 +157,4 @@ public class PostsService {
             return PostSummaryDto.of(post, postLikesCount);
         }).toList();
     }
-
 }

--- a/backend/src/main/java/com/trend_now/backend/post/application/PostsService.java
+++ b/backend/src/main/java/com/trend_now/backend/post/application/PostsService.java
@@ -8,11 +8,13 @@ package com.trend_now.backend.post.application;
 
 import com.trend_now.backend.board.domain.Boards;
 import com.trend_now.backend.board.repository.BoardRepository;
+import com.trend_now.backend.comment.repository.CommentsRepository;
 import com.trend_now.backend.image.application.ImagesService;
 import com.trend_now.backend.image.domain.Images;
 import com.trend_now.backend.image.dto.ImageInfoDto;
 import com.trend_now.backend.member.domain.Members;
 import com.trend_now.backend.post.domain.Posts;
+import com.trend_now.backend.post.dto.PostListPagingResponseDto;
 import com.trend_now.backend.post.dto.PostSummaryDto;
 import com.trend_now.backend.post.dto.PostsInfoDto;
 import com.trend_now.backend.post.dto.PostsPagingRequestDto;
@@ -23,6 +25,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -42,6 +45,7 @@ public class PostsService {
     private final BoardRepository boardRepository;
     private final ImagesService imagesService;
     private final PostLikesService postLikesService;
+    private final CommentsRepository commentsRepository;
 
     // 게시판 조회 - 가변 타이머 작동 중에만 가능
     public List<PostSummaryDto> findAllPostsPagingByBoardId(
@@ -141,20 +145,23 @@ public class PostsService {
         if (posts.isNotSameId(memberId)) {
             throw new IllegalArgumentException(NOT_SAME_WRITER);
         }
-        // TODO: 해당 게시글에 연관된 댓글 삭제
+        // 게시글에 연관된 댓글 삭제
+        commentsRepository.deleteByPosts_Id(postId);
         // 게시글에 등록된 이미지 삭제
         imagesService.deleteImageByPostId(posts.getId());
         // 게시글 삭제
         postsRepository.deleteById(postId);
     }
 
-    public List<PostSummaryDto> getPostsByMemberId(Long memberId, int page, int size) {
+    public Page<PostSummaryDto> getPostsByMemberId(Long memberId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Posts> posts = postsRepository.findByMembers_Id(memberId, pageable);
-        return posts.getContent().stream().map(post -> {
+        List<PostSummaryDto> postSummaryDtoList = posts.getContent().stream().map(post -> {
             int postLikesCount = postLikesService.getPostLikesCount(post.getBoards().getId(),
                 post.getId());
             return PostSummaryDto.of(post, postLikesCount);
         }).toList();
+
+        return new PageImpl<>(postSummaryDtoList, pageable, posts.getTotalElements());
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/post/application/ScrapService.java
+++ b/backend/src/main/java/com/trend_now/backend/post/application/ScrapService.java
@@ -6,6 +6,7 @@ import com.trend_now.backend.post.repository.ScrapRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,14 +20,17 @@ public class ScrapService {
     private final ScrapRepository scrapRepository;
     private final PostLikesService postLikesService;
 
-    public List<PostSummaryDto> getScrappedPostsByMemberId(Long memberId, int page, int size) {
+    public Page<PostSummaryDto> getScrappedPostsByMemberId(Long memberId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<Posts> scrapPosts = scrapRepository.findScrapPostsByMemberId(memberId, pageable);
 
-        return scrapPosts.getContent().stream().map(post -> {
+        List<PostSummaryDto> postSummaryDtoList = scrapPosts.getContent().stream().map(post -> {
             // 게시글 좋아요 개수 조회
-            int postLikesCount = postLikesService.getPostLikesCount(post.getBoards().getId(), post.getId());
+            int postLikesCount = postLikesService.getPostLikesCount(post.getBoards().getId(),
+                post.getId());
             return PostSummaryDto.of(post, postLikesCount);
         }).toList();
+
+        return new PageImpl<>(postSummaryDtoList, pageable, scrapPosts.getTotalElements());
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/post/dto/PostListPagingResponseDto.java
+++ b/backend/src/main/java/com/trend_now/backend/post/dto/PostListPagingResponseDto.java
@@ -13,9 +13,10 @@ import lombok.RequiredArgsConstructor;
 public class PostListPagingResponseDto {
 
     private final String message;
+    private final int totalPageCount;
     private final List<PostSummaryDto> postsInfoListDto;
 
-    public static PostListPagingResponseDto of(String message, List<PostSummaryDto> postsInfoListDto) {
-        return new PostListPagingResponseDto(message, postsInfoListDto);
+    public static PostListPagingResponseDto of(String message, int totalPageCount, List<PostSummaryDto> postsInfoListDto) {
+        return new PostListPagingResponseDto(message, totalPageCount, postsInfoListDto);
     }
 }

--- a/backend/src/test/java/com/trend_now/backend/comment/application/CommentsServiceTest.java
+++ b/backend/src/test/java/com/trend_now/backend/comment/application/CommentsServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.trend_now.backend.board.domain.BoardCategory;
 import com.trend_now.backend.board.domain.Boards;
 import com.trend_now.backend.board.repository.BoardRepository;
+import com.trend_now.backend.comment.data.dto.CommentListPagingResponseDto;
 import com.trend_now.backend.comment.data.dto.DeleteCommentsDto;
 import com.trend_now.backend.comment.data.dto.SaveCommentsDto;
 import com.trend_now.backend.comment.data.dto.UpdateCommentsDto;
@@ -73,24 +74,24 @@ class CommentsServiceTest {
     @BeforeEach
     public void setUp() {
         testMembers = memberRepository.save(Members.builder()
-                .name("testUser")
-                .email("testEmail")
-                .snsId("testSnsId")
-                .provider(Provider.TEST)
-                .build());
+            .name("testUser")
+            .email("testEmail")
+            .snsId("testSnsId")
+            .provider(Provider.TEST)
+            .build());
 
         testBoards = boaardRepository.save(Boards.builder()
-                .name("testBoards")
-                .boardCategory(BoardCategory.REALTIME)
-                .build());
+            .name("testBoards")
+            .boardCategory(BoardCategory.REALTIME)
+            .build());
 
         testPost = postsRepository.save(Posts.builder()
-                .title("testTitle")
-                .writer("testWriter")
-                .content("testContent")
-                .boards(testBoards)
-                .members(testMembers)
-                .build());
+            .title("testTitle")
+            .writer("testWriter")
+            .content("testContent")
+            .boards(testBoards)
+            .members(testMembers)
+            .build());
 
         em.flush();
         em.clear();
@@ -105,7 +106,8 @@ class CommentsServiceTest {
         redisTemplate.opsForValue().set(key, "실시간 게시판");
 
         SaveCommentsDto testSaveCommentsDto =
-                SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(), "testContent");
+            SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(),
+                "testContent");
 
         // when
         // BOARD_TTL 존재 했을 때, 댓글을 작성
@@ -129,7 +131,8 @@ class CommentsServiceTest {
         System.out.println("afterTtlComments : " + afterTtlComments.toString());
 
         // beforeTtlComment의 BoardTtlStatus는 "BOARD_TTL_BEFORE" 값을 가짐
-        assertThat(beforeTtlComments.getBoardTtlStatus()).isEqualTo(BoardTtlStatus.BOARD_TTL_BEFORE);
+        assertThat(beforeTtlComments.getBoardTtlStatus()).isEqualTo(
+            BoardTtlStatus.BOARD_TTL_BEFORE);
 
         // afterTtlComment의 BoardTtlStatus는 "BOARD_TTL_AFTER" 값을 가짐
         assertThat(afterTtlComments.getBoardTtlStatus()).isEqualTo(BoardTtlStatus.BOARD_TTL_AFTER);
@@ -145,7 +148,8 @@ class CommentsServiceTest {
         redisTemplate.opsForValue().set(key, "실시간 게시판");
 
         SaveCommentsDto testSaveCommentsDto =
-                SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(), "testContent");
+            SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(),
+                "testContent");
 
         commentsService.saveComments(testMembers, testSaveCommentsDto);
         commentsService.saveComments(testMembers, testSaveCommentsDto);
@@ -155,11 +159,10 @@ class CommentsServiceTest {
         Comments comments2 = commentsList.get(1);
 
         DeleteCommentsDto deleteCommentsDto1 = DeleteCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId());
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId());
 
         DeleteCommentsDto deleteCommentsDto2 = DeleteCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments2.getId());
-
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments2.getId());
 
         // when & then
         // 하나는 BOARD_TTL 전에 삭제하여 삭제됨을 확인 & 나머지 하나는 BOARD_TTL 후에 삭제하지만 삭제안됨을 확인
@@ -168,9 +171,10 @@ class CommentsServiceTest {
         // Redis에서 키 삭제하여 TTL 없는 상태로 만듦
         redisTemplate.delete(key);
 
-        assertThatThrownBy(() -> commentsService.deleteCommentsByCommentId(testMembers, deleteCommentsDto2))
-                .isInstanceOf(BoardTtlException.class)
-                .hasMessage("게시판 활성 시간이 만료되었습니다.");
+        assertThatThrownBy(
+            () -> commentsService.deleteCommentsByCommentId(testMembers, deleteCommentsDto2))
+            .isInstanceOf(BoardTtlException.class)
+            .hasMessage("게시판 활성 시간이 만료되었습니다.");
 
         commentsList = commentsRepository.findAll();
         System.out.println("commentsList >>> " + commentsList.toString());
@@ -187,7 +191,8 @@ class CommentsServiceTest {
         redisTemplate.opsForValue().set(key, "실시간 게시판");
 
         SaveCommentsDto testSaveCommentsDto =
-                SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(), "testContent");
+            SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(),
+                "testContent");
 
         commentsService.saveComments(testMembers, testSaveCommentsDto);
         commentsService.saveComments(testMembers, testSaveCommentsDto);
@@ -197,11 +202,12 @@ class CommentsServiceTest {
         Comments comments2 = commentsList.get(1);
 
         UpdateCommentsDto updateCommentsDto1 = UpdateCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId(), "test updated comments1");
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId(),
+            "test updated comments1");
 
         UpdateCommentsDto updateCommentsDto2 = UpdateCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments2.getId(), "test updated comments1");
-
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments2.getId(),
+            "test updated comments1");
 
         // when & then
         // 하나는 BOARD_TTL 전에 수정하여 수정됨을 확인 & 나머지 하나는 BOARD_TTL 후에 수정하지만 수정안됨을 확인
@@ -210,9 +216,10 @@ class CommentsServiceTest {
         // Redis에서 키 삭제하여 TTL 없는 상태로 만듦
         redisTemplate.delete(key);
 
-        assertThatThrownBy(() -> commentsService.updateCommentsByMembersAndCommentId(testMembers, updateCommentsDto2))
-                .isInstanceOf(BoardTtlException.class)
-                .hasMessage("게시판 활성 시간이 만료되었습니다.");
+        assertThatThrownBy(() -> commentsService.updateCommentsByMembersAndCommentId(testMembers,
+            updateCommentsDto2))
+            .isInstanceOf(BoardTtlException.class)
+            .hasMessage("게시판 활성 시간이 만료되었습니다.");
 
         commentsList = commentsRepository.findAll();
         System.out.println("commentsList >>> " + commentsList.toString());
@@ -234,17 +241,18 @@ class CommentsServiceTest {
 
         // testMembers가 comments1 댓글 작성
         SaveCommentsDto testSaveCommentsDto =
-                SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(), "testContent");
+            SaveCommentsDto.of(testBoards.getId(), testPost.getId(), testBoards.getName(),
+                "testContent");
 
         commentsService.saveComments(testMembers, testSaveCommentsDto);
 
         // 다른 사용자 생성 (testMembers2)
         Members testMembers2 = memberRepository.save(Members.builder()
-                .name("testUser2")
-                .email("testEmail2")
-                .snsId("testSnsId2")
-                .provider(Provider.TEST)
-                .build());
+            .name("testUser2")
+            .email("testEmail2")
+            .snsId("testSnsId2")
+            .provider(Provider.TEST)
+            .build());
 
         em.flush();
         em.clear();
@@ -255,29 +263,53 @@ class CommentsServiceTest {
 
         // 삭제 요청 DTO 생성
         DeleteCommentsDto deleteCommentsDto = DeleteCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId());
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId());
 
         // 수정 요청 DTO 생성
         UpdateCommentsDto updateCommentsDto = UpdateCommentsDto.of(
-                testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId(), "updated content");
+            testBoards.getId(), testPost.getId(), testBoards.getName(), comments1.getId(),
+            "updated content");
 
         // when & then
         // 임의 testMembers2가 comments1 댓글을 삭제 처리 요청 시,
         // InvalidRequestException 예외에 NOT_COMMENT_WRITER 메시지 발생해야 한다.
-        assertThatThrownBy(() -> commentsService.deleteCommentsByCommentId(testMembers2, deleteCommentsDto))
-                .isInstanceOf(InvalidRequestException.class)
-                .hasMessage("댓글 작성자가 아닙니다.");
+        assertThatThrownBy(
+            () -> commentsService.deleteCommentsByCommentId(testMembers2, deleteCommentsDto))
+            .isInstanceOf(InvalidRequestException.class)
+            .hasMessage("댓글 작성자가 아닙니다.");
 
         // 임의 testMembers2가 comments1 댓글을 수정 처리 요청 시,
         // InvalidRequestException 예외에 NOT_COMMENT_WRITER 메시지 발생해야 한다.
-        assertThatThrownBy(() -> commentsService.updateCommentsByMembersAndCommentId(testMembers2, updateCommentsDto))
-                .isInstanceOf(InvalidRequestException.class)
-                .hasMessage("댓글 작성자가 아닙니다.");
+        assertThatThrownBy(() -> commentsService.updateCommentsByMembersAndCommentId(testMembers2,
+            updateCommentsDto))
+            .isInstanceOf(InvalidRequestException.class)
+            .hasMessage("댓글 작성자가 아닙니다.");
 
         // 댓글이 여전히 존재하고 변경되지 않았는지 확인
         commentsList = commentsRepository.findAll();
         assertThat(commentsList).hasSize(1);
         assertThat(commentsList.get(0).getContent()).isEqualTo("testContent");
         assertThat(commentsList.get(0).getMembers().getId()).isEqualTo(testMembers.getId());
+    }
+
+    @Test
+    @DisplayName("내가 작성한 댓글을 조회할 수 있다.")
+    public void 내가_작성한_댓글_조회() throws Exception {
+        //given
+        for (int i = 1; i <= 10; i++) {
+            SaveCommentsDto testSaveCommentsDto = SaveCommentsDto.of(testBoards.getId(),
+                testPost.getId(), testBoards.getName(), "testContent" + i);
+            commentsService.saveComments(testMembers, testSaveCommentsDto);
+        }
+        //when
+        CommentListPagingResponseDto commentsByMemberId = commentsService.getCommentsByMemberId(
+            testMembers.getId(), 0, 5);
+
+        //then
+        assertThat(commentsByMemberId.getTotalPageCount()).isEqualTo(2);
+        // 최신순으로 조회되기 때문에 마지막에 저장된 댓글이 첫번째 값
+        assertThat(commentsByMemberId.getCommentsInfoListDto().getFirst().getContent()).isEqualTo("testContent10");
+        assertThat(commentsByMemberId.getCommentsInfoListDto().getLast().getPostTitle()).isEqualTo(testPost.getTitle());
+
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-46] 마이페이지 정보 조회 기능 추가 및 수정

## 🔗 관련 이슈
- #57 

## ✍️ 변경 사항
- 마이페이지에서 사용자의 이름과 이메일 조회 기능 추가
- 사용자가 작성한 댓글 조회 기능 추가
- 게시글과 댓글 목록을 반환할 때 totalPageCount 포함해서 반환
- join + pageable 사용 시 countQuery 추가

## ✅ 체크리스트
- [x] PR 제목이 적절한가요?
- [x] 관련 이슈가 연결되었나요?
- [x] 변경 사항을 충분히 설명했나요?
- [x] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 

[CCS-46]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ