### PR TITLE
[refactor][CCS-49] 테스트 JWT API 호출 시, DB 데이터 저장하지 않도록 진행

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -125,16 +125,26 @@ public class MemberService {
         log.info("닉네임 변경 완료 - {}", member.getName());
     }
 
+    /**
+     * test jwt 값을 얻기 위해서 test 계정을 이용하여 JWT 값 생성 및 반환
+     * - test 계정이 있으면 해당 계정의 id 값을 가져와 JWT 값 생성
+     * - test 계정이 없으면 해당 계정을 저장 후, id 값을 가져와 JWT 값 생성
+     */
     @Transactional
     public String getTestJwt() {
-        Members testMember = Members.builder()
-                .name("test_name")
-                .email("test_email")
-                .provider(Provider.TEST)
-                .snsId("test_snsId")
-                .build();
+        Members testMember = memberRepository.findBySnsId("test_snsId")
+                .orElseGet(
+                        () -> memberRepository.save(
+                                Members.builder()
+                                        .name("test_name")
+                                        .email("test_email")
+                                        .provider(Provider.TEST)
+                                        .snsId("test_snsId")
+                                        .build()
+                        )
+                );
 
-        String testJwt = jwtTokenProvider.createToken(memberRepository.save(testMember).getId());
+        String testJwt = jwtTokenProvider.createToken(testMember.getId());
         log.info("[MemberService.getTestJwt] : 테스트용 JWT = {}", testJwt);
         return testJwt;
     }

--- a/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/member/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Members, Long> {
     boolean existsByName(String name);
 
     Optional<Members> findByName(String name);
+
+    List<Members> findAllBySnsId(String testSnsId);
 }


### PR DESCRIPTION
## 📌 PR 제목
[refactor][CCS-49] 테스트 JWT API 호출 시, DB 데이터 저장하지 않도록 진행

## 🔗 관련 이슈
- #68  

## ✍️ 변경 사항
- test-jwt API를 여러 번 호출해도 JWT 값 반환하도록 수정
- test-jwt API 호출 시, 테스트 계정을 중복으로 DB에 저장하는 로직을 삭제

## ✅ 체크리스트
- [x] PR 제목이 적절한가요?
- [x] 관련 이슈가 연결되었나요?
- [x] 변경 사항을 충분히 설명했나요?
- [x] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)


[CCS-49]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ