### PR TITLE
[feat][CCS-53] 실시간 게시판을 조회했을 때 필요한 정보(게시판 이름, 게시판 남은 시간) 반환

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -1,12 +1,20 @@
 package com.trend_now.backend.board.application;
 
 import com.trend_now.backend.board.domain.BoardCategory;
+import com.trend_now.backend.board.domain.Boards;
 import com.trend_now.backend.board.dto.BoardInfoDto;
 import com.trend_now.backend.board.dto.BoardPagingRequestDto;
 import com.trend_now.backend.board.dto.BoardPagingResponseDto;
 import com.trend_now.backend.board.dto.BoardSaveDto;
+import com.trend_now.backend.board.repository.BoardRepository;
+import com.trend_now.backend.exception.CustomException.NotFoundException;
 import java.time.LocalTime;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +41,10 @@ public class BoardRedisService {
     private static final long KEY_LIVE_TIME = 301L;
     private static final int KEY_EXPIRE = 0;
 
+    private static final String NOT_EXIST_BOARD = "선택하신 게시판이 존재하지 않습니다.";
+
     private final RedisTemplate<String, String> redisTemplate;
+    private final BoardRepository boardRepository;
 
     public void saveBoardRedis(BoardSaveDto boardSaveDto, int score) {
         String key = boardSaveDto.getBoardName() + BOARD_KEY_DELIMITER + boardSaveDto.getBoardId();
@@ -51,7 +62,7 @@ public class BoardRedisService {
 
     public void setRankValidListTime() {
         String validTime = Long.toString(
-            LocalTime.now().plusSeconds(KEY_LIVE_TIME).toSecondOfDay());
+                LocalTime.now().plusSeconds(KEY_LIVE_TIME).toSecondOfDay());
         redisTemplate.opsForValue().set(BOARD_RANK_VALID_KEY, validTime);
     }
 
@@ -62,14 +73,13 @@ public class BoardRedisService {
         }
 
         allRankKey.stream()
-            .filter(key -> !Boolean.TRUE.equals(redisTemplate.hasKey(key)))
-            .forEach(key -> redisTemplate.opsForZSet().remove(BOARD_RANK_KEY, key));
+                .filter(key -> !Boolean.TRUE.equals(redisTemplate.hasKey(key)))
+                .forEach(key -> redisTemplate.opsForZSet().remove(BOARD_RANK_KEY, key));
     }
 
     /**
-     * BoardKeyProvider 인터페이스를 통해서 isRealTimeBoard 메서드에 접근한다.
-     * - 특정 DTO에만 종속되는 한계에서 확장성을 고려하여 설계
-     * - isRealTimeBoard 메서드에 접근할려는 DTO는 BoardKeyProvider 인터페이스를 구현체로 진행
+     * BoardKeyProvider 인터페이스를 통해서 isRealTimeBoard 메서드에 접근한다. - 특정 DTO에만 종속되는 한계에서 확장성을 고려하여 설계 -
+     * isRealTimeBoard 메서드에 접근할려는 DTO는 BoardKeyProvider 인터페이스를 구현체로 진행
      */
     public boolean isRealTimeBoard(BoardKeyProvider provider) {
         String key = provider.getBoardName() + BOARD_KEY_DELIMITER + provider.getBoardId();
@@ -86,7 +96,7 @@ public class BoardRedisService {
     }
 
     public BoardPagingResponseDto findAllRealTimeBoardPaging(
-        BoardPagingRequestDto boardPagingRequestDto) {
+            BoardPagingRequestDto boardPagingRequestDto) {
         Set<String> allBoardName = getBoardRank();
 
         if (allBoardName == null || allBoardName.isEmpty()) {
@@ -94,30 +104,31 @@ public class BoardRedisService {
         }
 
         List<BoardInfoDto> boardInfoDtos = allBoardName.stream()
-            .map(boardKey -> {
-                // boardId 추출
-                String[] parts = boardKey.split(BOARD_KEY_DELIMITER);
-                log.info("[BoardRedisService.findAllRealTimeBoardPaging] : parts = {}",
-                    Arrays.toString(parts));
+                .map(boardKey -> {
+                    // boardId 추출
+                    String[] parts = boardKey.split(BOARD_KEY_DELIMITER);
+                    log.info("[BoardRedisService.findAllRealTimeBoardPaging] : parts = {}",
+                            Arrays.toString(parts));
 
-                // 데이터 타입 이상 시, 다음으로 넘김
-                if (parts.length < BOARD_KEY_PARTS_LENGTH)
-                    return null;
+                    // 데이터 타입 이상 시, 다음으로 넘김
+                    if (parts.length < BOARD_KEY_PARTS_LENGTH) {
+                        return null;
+                    }
 
-                String boardName = parts[BOARD_NAME_INDEX];
-                Long boardId = Long.parseLong(parts[BOARD_ID_INDEX]);
+                    String boardName = parts[BOARD_NAME_INDEX];
+                    Long boardId = Long.parseLong(parts[BOARD_ID_INDEX]);
 
-                Long boardLiveTime = redisTemplate.getExpire(boardKey, TimeUnit.SECONDS);
-                Double score = redisTemplate.opsForZSet().score(BOARD_RANK_KEY, boardKey);
-                return new BoardInfoDto(boardId, boardName, boardLiveTime, score);
-            })
-            .filter(Objects::nonNull)
-            .sorted(Comparator.comparingLong(BoardInfoDto::getBoardLiveTime).reversed()
-                .thenComparingDouble(BoardInfoDto::getScore))
-            .collect(Collectors.toList());
+                    Long boardLiveTime = redisTemplate.getExpire(boardKey, TimeUnit.SECONDS);
+                    Double score = redisTemplate.opsForZSet().score(BOARD_RANK_KEY, boardKey);
+                    return new BoardInfoDto(boardId, boardName, boardLiveTime, score);
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparingLong(BoardInfoDto::getBoardLiveTime).reversed()
+                        .thenComparingDouble(BoardInfoDto::getScore))
+                .collect(Collectors.toList());
 
         PageRequest pageRequest = PageRequest.of(boardPagingRequestDto.getPage(),
-            boardPagingRequestDto.getSize(), Sort.by(Direction.DESC, "createdAt"));
+                boardPagingRequestDto.getSize(), Sort.by(Direction.DESC, "createdAt"));
         int start = (int) pageRequest.getOffset();
         int end = Math.min(start + pageRequest.getPageSize(), boardInfoDtos.size());
 
@@ -130,5 +141,19 @@ public class BoardRedisService {
 
     public String getBoardRankValidTime() {
         return redisTemplate.opsForValue().get(BOARD_RANK_VALID_KEY);
+    }
+
+    public BoardInfoDto getBoardInfo(Long boardId) {
+        Boards findBoard = boardRepository.findById(boardId)
+                .orElseThrow(() -> new NotFoundException(NOT_EXIST_BOARD));
+
+        String key = findBoard.getName() + BOARD_KEY_DELIMITER + findBoard.getId();
+        Long boardLiveTime = redisTemplate.getExpire(key, TimeUnit.SECONDS);
+
+        return BoardInfoDto.builder()
+                .boardId(findBoard.getId())
+                .boardName(findBoard.getName())
+                .boardLiveTime(boardLiveTime)
+                .build();
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/board/presentation/BoardController.java
+++ b/backend/src/main/java/com/trend_now/backend/board/presentation/BoardController.java
@@ -2,10 +2,11 @@ package com.trend_now.backend.board.presentation;
 
 import com.trend_now.backend.board.application.BoardRedisService;
 import com.trend_now.backend.board.application.BoardService;
+import com.trend_now.backend.board.dto.BoardInfoDto;
 import com.trend_now.backend.board.dto.BoardPagingRequestDto;
 import com.trend_now.backend.board.dto.BoardPagingResponseDto;
-import com.trend_now.backend.board.dto.RealtimeBoardListDto;
 import com.trend_now.backend.board.dto.FixedBoardSaveDto;
+import com.trend_now.backend.board.dto.RealtimeBoardListDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -52,5 +53,13 @@ public class BoardController {
     public ResponseEntity<String> addFixedBoard(@RequestBody FixedBoardSaveDto fixedBoardSaveDto) {
         boardService.addFixedBoard(fixedBoardSaveDto);
         return ResponseEntity.status(HttpStatus.OK).body("고정 게시판 항목이 추가되었습니다.");
+    }
+
+    @Operation(summary = "실시간 게시판 정보 반환", description = "실시간 게시판 입장 시 필요한 정보를 반환합니다.")
+    @GetMapping("/realtime")
+    public ResponseEntity<BoardInfoDto> getBoardInfo(
+            @RequestParam Long boardId) {
+        BoardInfoDto boardInfo = boardRedisService.getBoardInfo(boardId);
+        return ResponseEntity.status(HttpStatus.OK).body(boardInfo);
     }
 }

--- a/backend/src/test/java/com/trend_now/backend/board/controller/BoardsControllerTest.java
+++ b/backend/src/test/java/com/trend_now/backend/board/controller/BoardsControllerTest.java
@@ -13,6 +13,8 @@ import com.trend_now.backend.board.dto.Top10;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -92,4 +94,21 @@ public class BoardsControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("실시간 게시판을 들어갔을 때 실시간 게시판의 정보를 받을 수 있다")
+    public void 실시간_게시판_정보() throws Exception {
+        //given
+        Long boardId = 5L;
+
+        //when
+
+        //then
+        mockMvc.perform(get("/api/v1/boards/realtime")
+                        .param("boardId", String.valueOf(boardId))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-53] 실시간 게시판을 조회했을 때 필요한 정보(게시판 이름, 게시판 남은 시간) 반환

## 🔗 관련 이슈
- #89 

## ✍️ 변경 사항
- 기존에 만들었던 BoardInfoDto로 실시간 게시판을 조회했을 때 필요한 정보를 반환했습니다.

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 실시간 게시판 날짜 이력을 어떻게 구현하면 좋을지 고민해야 할 것 같습니다.