### PR TITLE
[fix][CCS-55] 댓글 조회 API에 isMyComments 필드 삭제

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/application/CommentsService.java
@@ -185,27 +185,15 @@ public class CommentsService {
 
     /**
      * 댓글을 조회할 때, 페이지네이션에 따른 기본 댓글 정보와 총 댓글 개수와 페이지 개수를 같이 제공
-     * 로그인 유저인 경우, 자신이 작성한 댓글인지 여부도 같이 제공
-     * 비로그인 유저인 경우, 자신이 작성한 댓글인지 여부는 항상 false로 제공
      */
-    public FindCommentsResponse findAllCommentsByPostId(Long postId, Pageable pageable, String jwt) {
+    public FindCommentsResponse findAllCommentsByPostId(Long postId, Pageable pageable) {
         // Page객체를 이용하여 댓글 데이터 조회
         Page<FindAllCommentsDto> comments = commentsRepository.findByPostsIdOrderByCreatedAtDesc(postId, pageable);
 
-        // Page 객체에서 필요한 데이터만 사용하기 위해 List 객체로 변환해줌
-        List<FindAllCommentsDto> commentsList = comments.getContent().stream()
-                .map(comment -> FindAllCommentsDto.builder()
-                        .createdAt(comment.getCreatedAt())
-                        .updatedAt(comment.getUpdatedAt())
-                        .id(comment.getId())
-                        .content(comment.getContent())
-                        .modifiable(comment.isModifiable())
-                        .writer(comment.getWriter())
-                        .writerId(comment.getWriterId())
-                        .isMyComments(jwtTokenFilter.checkMemberIdFromToken(comment.getWriterId(), jwt))
-                        .build())
-                .toList();
-
-        return new FindCommentsResponse((int) comments.getTotalElements(), comments.getTotalPages(), commentsList);
+        return new FindCommentsResponse(
+                (int) comments.getTotalElements()
+                , comments.getTotalPages()
+                , comments.getContent()
+        );
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/data/dto/FindAllCommentsDto.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/data/dto/FindAllCommentsDto.java
@@ -22,20 +22,4 @@ public class FindAllCommentsDto {
 
     // 댓글 작성자 식별자
     private final Long writerId;
-
-    // 댓글 작성자 본인 여부
-    private final boolean isMyComments;
-
-    // 기본 댓글 정보 JPQL 프로젝션용 생성자
-    public FindAllCommentsDto(LocalDateTime createdAt, LocalDateTime updatedAt, Long id, String content
-            , boolean modifiable, String writer, Long writerId) {
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.id = id;
-        this.content = content;
-        this.modifiable = modifiable;
-        this.writer = writer;
-        this.writerId = writerId;
-        this.isMyComments = false;
-    }
 }

--- a/backend/src/main/java/com/trend_now/backend/comment/presentation/CommentsController.java
+++ b/backend/src/main/java/com/trend_now/backend/comment/presentation/CommentsController.java
@@ -49,14 +49,13 @@ public class CommentsController {
     @Operation(summary = "댓글 조회", description = "게시글에 댓글을 조회합니다.")
     @GetMapping()
     public ResponseEntity<FindCommentsResponse> findAllCommentsByPostId(
-            @RequestHeader(value = "jwt", required = false) String jwt
-            , @PathVariable Long postId
+            @PathVariable Long postId
             , @RequestParam(required = false, defaultValue = "1") int page
             , @RequestParam(required = false, defaultValue = "1") int size) {
         // PageRequest 객체 생성 (page는 0부터 시작하므로 -1)
         Pageable pageable = PageRequest.of(page - 1, size);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(commentsService.findAllCommentsByPostId(postId, pageable, jwt));
+                .body(commentsService.findAllCommentsByPostId(postId, pageable));
     }
 
     @Operation(summary = "댓글 삭제", description = "특정 게시판의 BOARD_TTL 만료 시간 안의 댓글을 삭제합니다.")

--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
@@ -123,35 +123,4 @@ public class JwtTokenFilter extends GenericFilter {
             return null;
         }
     }
-
-    /**
-     * JWT을 디코딩한 memberId와 입력한 memberId가 동일한지 확인 메서드
-     */
-    public boolean checkMemberIdFromToken(Long memberId, String token) {
-        // 비로그인 사용자인 경우, false 반환
-        if (token == null || token.trim().isEmpty()) {
-            return false;
-        }
-
-        try {
-            // Bearer 접두사가 있는 경우 제거
-            String jwtToken = token;
-            if (token.startsWith(JWT_PREFIX)) {
-                jwtToken = token.substring(7);
-                log.debug("[JwtTokenFilter.checkMemberIdFromToken] Bearer 접두사 제거: {}", jwtToken);
-            }
-
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(jwtToken)
-                    .getBody();
-
-            String subject = claims.getSubject();
-            return Long.valueOf(subject).equals(memberId);
-        } catch (Exception e) {
-            log.error("[JwtTokenProvider.getMemberIdFromToken] JWT 토큰 파싱 실패: {}", e.getMessage());
-            return false;
-        }
-    }
 }


### PR DESCRIPTION
## 📌 PR 제목
[fix][CCS-55] 실시간 검색어 순위 변동 알고리즘 수정

## 🔗 관련 이슈
- #94

## ✍️ 변경 사항
- 댓글 조회 API에 isMyComments 필드는 프론트엔드에서 처리한다고 하여 백엔드 로직에서 삭제
- 댓글 조회 서비스 로직 단순화


## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 서비스 레이어에서 컨트롤러로 반환할 때, 간결하게 반환하도록 수정했습니다. 해당 부분에 대해서 피드백 부탁드립니다.

[CCS-55]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ