### PR TITLE
[feat][CCS-61] 같은 게시판에 대해 게시글 작성 5분 제한

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/post/dto/CheckPostCooldownResponse.java
+++ b/backend/src/main/java/com/trend_now/backend/post/dto/CheckPostCooldownResponse.java
@@ -1,0 +1,15 @@
+package com.trend_now.backend.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CheckPostCooldownResponse {
+    private boolean canWritePost;
+    private Long cooldownSeconds;
+
+    public static CheckPostCooldownResponse of(boolean canWritePost, Long cooldownSeconds) {
+        return new CheckPostCooldownResponse(canWritePost, cooldownSeconds);
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/post/presentation/PostsController.java
+++ b/backend/src/main/java/com/trend_now/backend/post/presentation/PostsController.java
@@ -5,6 +5,7 @@ import com.trend_now.backend.image.application.ImagesService;
 import com.trend_now.backend.image.dto.ImageInfoDto;
 import com.trend_now.backend.member.domain.Members;
 import com.trend_now.backend.post.application.PostsService;
+import com.trend_now.backend.post.dto.CheckPostCooldownResponse;
 import com.trend_now.backend.post.dto.PostInfoResponseDto;
 import com.trend_now.backend.post.dto.PostSummaryDto;
 import com.trend_now.backend.post.dto.PostsInfoDto;
@@ -64,7 +65,8 @@ public class PostsController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(PostListResponseDto.of(SUCCESS_PAGING_POSTS_MESSAGE,
-                postSummaryDtoPage.getTotalPages(), postSummaryDtoPage.getTotalElements(), boardName, postSummaryDtoPage.getContent()));
+                postSummaryDtoPage.getTotalPages(), postSummaryDtoPage.getTotalElements(),
+                boardName, postSummaryDtoPage.getContent()));
     }
 
     @Operation(summary = "게시글 상세 조회", description = "게시판의 게시글을 상세 조회합니다.")
@@ -117,5 +119,15 @@ public class PostsController {
         postsService.deletePostsById(boardId, postId, members.getId());
 
         return ResponseEntity.status(HttpStatus.OK).body(SUCCESS_DELETE_POSTS_MESSAGE);
+    }
+
+    @Operation(summary = "게시판 글쓰기 가능 여부 확인", description = "요청한 사용자가 현재 게시판에 게시글을 작성한 후 5분 이내에는 추가 작성이 불가능하도록 쿨다운 상태를 확인합니다.")
+    @GetMapping("/posts/cooldown")
+    public ResponseEntity<CheckPostCooldownResponse> checkPostCooldown(
+        @PathVariable(value = "boardId") Long boardId,
+        @AuthenticationPrincipal(expression = "members") Members members) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(postsService.checkPostCooldown(boardId, members.getId()));
     }
 }

--- a/backend/src/test/java/com/trend_now/backend/unit_test/posts/service/PostsServiceTest.java
+++ b/backend/src/test/java/com/trend_now/backend/unit_test/posts/service/PostsServiceTest.java
@@ -1,0 +1,111 @@
+package com.trend_now.backend.unit_test.posts.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.trend_now.backend.board.application.BoardRedisService;
+import com.trend_now.backend.board.domain.BoardCategory;
+import com.trend_now.backend.board.domain.Boards;
+import com.trend_now.backend.board.repository.BoardRepository;
+import com.trend_now.backend.member.domain.Members;
+import com.trend_now.backend.post.application.PostsService;
+import com.trend_now.backend.post.domain.Posts;
+import com.trend_now.backend.post.dto.PostsSaveDto;
+import com.trend_now.backend.post.repository.PostsRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@DisplayName("PostsService 단위 테스트")
+public class PostsServiceTest {
+
+    @Mock
+    private PostsRepository postsRepository;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private BoardRedisService boardRedisService;
+
+    @Mock
+    private RedisTemplate<Object, Object> redisTemplate;
+
+    @Mock
+    private HashOperations<Object, Object, Object> hashOperations;
+
+    @InjectMocks
+    private PostsService postsService;
+
+    @BeforeEach
+    void setUp() {
+        // 실제 Redis가 아닌 직접 정의한 Mock 객체를 사용
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+    }
+
+    @Test
+    @DisplayName("같은 회원이 같은 게시판에서 게시글 작성 이후 5분 이내에 다시 게시글을 작성할 수 없다")
+    void 같은_회원이_같은_게시판에서_게시글_작성_이후_5분_이내에_다시_게시글을_작성할_수_없다() {
+        // given
+        long memberId = 1L;
+        long boardId = 1L;
+        Members members = Members.builder()
+            .id(memberId)
+            .name("testUser")
+            .email("test123@test.com")
+            .build();
+
+        Boards board = Boards.builder()
+            .id(boardId)
+            .name("testBoard")
+            .boardCategory(BoardCategory.REALTIME)
+            .build();
+
+        PostsSaveDto dto = PostsSaveDto.of("testTitle", "testContent", null);
+        String boardUserKey = String.format("board:%s:user:%s", boardId, memberId);
+        String lastPostTimeKey = "last_post_time";
+
+        when(boardRepository.findById(boardId)).thenReturn(Optional.of(board));
+        when(boardRedisService.isNotRealTimeBoard(any(), any(), any())).thenReturn(false);
+        // 게시글 최초 작성 시에는 Redis에 저장된 시간이 없으므로 null을 반환
+        when(hashOperations.get(boardUserKey, lastPostTimeKey)).thenReturn(null);
+
+        // when
+        postsService.savePosts(dto, members, boardId);
+
+        // then
+        verify(postsRepository, times(1)).save(any(Posts.class));
+        // Redis에 게시글 작성 시간을 저장하는 put 메서드가 호출 되었는지 확인
+        verify(hashOperations, times(1)).put(eq(boardUserKey), eq(lastPostTimeKey), anyLong());
+
+        // given
+        // 게시글을 작성했기 때문에 Redis에 작성 시간이 저장되어 있어야 함
+        long currentTime = System.currentTimeMillis();
+        when(hashOperations.get(boardUserKey, lastPostTimeKey)).thenReturn(currentTime);
+
+        // when & then
+        // 5분 이내에 다시 게시글을 작성하려고 시도했기 때문에 예외 발생
+        assertThrows(IllegalStateException.class, () -> {
+            postsService.savePosts(dto, members, boardId);
+        });
+
+        // 게시글 작성 시도는 2번이었지만, 실제로 save 메서드는 1번만 실행됐어야 함
+        verify(postsRepository, times(1)).save(any(Posts.class));
+    }
+}
+


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-61] 같은 게시판에 대해 게시글 작성 5분 제한

## 🔗 관련 이슈
- #108 

## ✍️ 변경 사항
- 회원이 게시글을 최초 작성한 이후 5분이 지나지 않았으면 게시글 작성 불가능
- 회원이 게시글을 등록하는 시점에 Redis에 해당 게시판에 대한 작성 시간을 저장
- 게시글 '등록' 버튼이 아닌, '작성' 버튼을 클릭했을 때 안내가 될 수 있도록 API 추가
- 게시글 작성 제한에 대한 단위 테스트 코드 추가

## ✅ 체크리스트
- [x] PR 제목이 적절한가요?
- [x] 관련 이슈가 연결되었나요?
- [x] 변경 사항을 충분히 설명했나요?
- [x] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 현재 test 패키지 안에 통합 테스트와 테스트 코드가 모두 존재해야 하는데 test 패키지의 디렉토리 구조를 어떻게 잡는게 좋을까요?