### PR TITLE
[refactor][CCS-62] 실시간 게시판 목록 응답에 총 게시판 수,  총 조회수 추가

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -218,8 +218,6 @@ public class BoardRedisService {
             .sorted(Comparator.comparingLong(RealtimeBoardListDto::getBoardLiveTime).reversed()
                 .thenComparingDouble(RealtimeBoardListDto::getScore))
             .toList();
-//        List<BoardInfoDto> boardInfoDtos = allBoardName.stream()
-
 
         PageRequest pageRequest = PageRequest.of(boardPagingRequestDto.getPage(),
                 boardPagingRequestDto.getSize(), Sort.by(Direction.DESC, "createdAt"));

--- a/backend/src/main/java/com/trend_now/backend/board/dto/BoardPagingResponseDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/BoardPagingResponseDto.java
@@ -8,9 +8,9 @@ import lombok.Data;
 @AllArgsConstructor
 public class BoardPagingResponseDto {
 
-    private List<BoardInfoDto> boardInfoDtos;
+    private List<RealtimeBoardListDto> boardInfoDtos;
 
-    public static BoardPagingResponseDto from(List<BoardInfoDto> boardInfoDtos) {
-        return new BoardPagingResponseDto(boardInfoDtos);
+    public static BoardPagingResponseDto from(List<RealtimeBoardListDto> boardInfoDtoList) {
+        return new BoardPagingResponseDto(boardInfoDtoList);
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/board/dto/RealtimeBoardListDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/RealtimeBoardListDto.java
@@ -16,6 +16,8 @@ public class RealtimeBoardListDto {
     private Long viewCount;
     @Setter
     private Long boardLiveTime;
+    @Setter
+    private Double score;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/trend_now/backend/board/repository/BoardRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/board/repository/BoardRepository.java
@@ -33,4 +33,22 @@ public interface BoardRepository extends JpaRepository<Boards, Long> {
         GROUP BY b.id, b.name, b.createdAt, b.updatedAt
         """)
     List<RealtimeBoardListDto> findRealtimeBoardsByIds(List<Long> ids);
+
+    @Query("""
+        SELECT new com.trend_now.backend.board.dto.RealtimeBoardListDto(
+                b.id,
+                b.name,
+                COALESCE(COUNT(p.id), 0),
+                COALESCE(SUM(p.viewCount), 0),
+                b.createdAt,
+                b.updatedAt
+            )
+            FROM Boards b
+            LEFT JOIN Posts p ON p.boards.id = b.id
+            WHERE b.id = :boardId
+            GROUP BY b.id, b.name, b.createdAt, b.updatedAt
+        """)
+    RealtimeBoardListDto findRealtimeBoardById(Long boardId);
+
+
 }


### PR DESCRIPTION
## 📌 PR 제목
[refactor][CCS-62] 실시간 게시판 목록 응답에 총 게시판 수,  총 조회수 추가

## 🔗 관련 이슈
- #111 

## ✍️ 변경 사항
- 실시간 게시판 목록 API 응답에 총 게시판 수,  총 조회수 값이 추가된다.

## ✅ 체크리스트
- [x] PR 제목이 적절한가요?
- [x] 관련 이슈가 연결되었나요?
- [x] 변경 사항을 충분히 설명했나요?
- [x] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)

[CCS-62]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ