### PR TITLE
[refactor][CCS-63] 실시간 게시판 정보를 반환할 때 해당 게시판의 소멸 시간을 포함하도록 수정

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -201,7 +201,10 @@ public class BoardRedisService {
 
                     Long boardLiveTime = redisTemplate.getExpire(boardKey, TimeUnit.SECONDS);
                     Double score = redisTemplate.opsForZSet().score(BOARD_RANK_KEY, boardKey);
-                    return new BoardInfoDto(boardId, boardName, boardLiveTime, score);
+
+                    // 게시판 만료 시각을 ms 단위로 계산
+                    Long expiredBoardTime = System.currentTimeMillis() + (boardLiveTime * 1000);
+                    return new BoardInfoDto(boardId, boardName, boardLiveTime, expiredBoardTime, score);
                 })
                 .filter(Objects::nonNull)
                 .sorted(Comparator.comparingLong(BoardInfoDto::getBoardLiveTime).reversed()
@@ -231,10 +234,14 @@ public class BoardRedisService {
         String key = findBoard.getName() + BOARD_KEY_DELIMITER + findBoard.getId();
         Long boardLiveTime = redisTemplate.getExpire(key, TimeUnit.SECONDS);
 
+        // 게시판 만료 시각을 ms 단위로 계산
+        Long expiredBoardTime = System.currentTimeMillis() + (boardLiveTime * 1000);
+
         return BoardInfoDto.builder()
                 .boardId(findBoard.getId())
                 .boardName(findBoard.getName())
                 .boardLiveTime(boardLiveTime)
+                .boardExpiredTime(expiredBoardTime)
                 .build();
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/board/dto/BoardInfoDto.java
+++ b/backend/src/main/java/com/trend_now/backend/board/dto/BoardInfoDto.java
@@ -12,5 +12,6 @@ public class BoardInfoDto {
     private Long boardId;
     private String boardName;
     private long boardLiveTime;
+    private long boardExpiredTime;
     private double score;
 }


### PR DESCRIPTION
## 📌 PR 제목
[refactor][CCS-63] 실시간 게시판 정보를 반환할 때 해당 게시판의 소멸 시간을 포함하도록 수정

## 🔗 관련 이슈
- #114 

## ✍️ 변경 사항
- 실시간 게시판 정보에 해당 게시판의 소멸 시간이 포함되었습니다.

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 

[CCS-63]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ