### PR TITLE
[refactor][CCS-67] 실시간 게시판 score을 UTC 기준 시각을 사용하여 만료 시간으로 세팅하도록 변경

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -13,7 +13,9 @@ import com.trend_now.backend.board.repository.BoardRepository;
 import com.trend_now.backend.exception.CustomException.NotFoundException;
 import com.trend_now.backend.post.application.PostLikesService;
 import com.trend_now.backend.post.application.PostViewService;
+import java.time.Instant;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -60,7 +62,7 @@ public class BoardRedisService {
     private final PostLikesService postLikesService;
     private final BoardCache boardCache;
 
-    public void saveBoardRedis(BoardSaveDto boardSaveDto, int score) {
+    public void saveBoardRedis(BoardSaveDto boardSaveDto, double score) {
         String key = boardSaveDto.getBoardName() + BOARD_KEY_DELIMITER + boardSaveDto.getBoardId();
         long keyLiveTime = KEY_LIVE_TIME;
 
@@ -113,8 +115,21 @@ public class BoardRedisService {
 
     private void extendBoardExpireTime(String key, Long currentExpireTime, long additionalSeconds,
             String thresholdKey) {
+        // 실시간 게시판의 남은 시간(TTL)이 증가
         redisTemplate.expire(key, currentExpireTime + additionalSeconds, TimeUnit.SECONDS);
         redisTemplate.opsForSet().add(BOARD_THRESHOLD_KEY, thresholdKey);
+
+        // TTL이 증가하는 만큼 score도 증가
+        Double currentScore = redisTemplate.opsForZSet()
+                .score(BOARD_RANK_KEY, key); // 현재 저장된 만료 시간을 가져옴
+        if (currentScore == null) {
+            return; // 실시간 게시판이 아직 등록되지 않은 경우
+        }
+
+        // 실시간 게시판의 score로 증가된 시간이 세팅
+        Instant currentExpireScore = Instant.ofEpochMilli(currentScore.longValue());
+        Instant newExpireScore = currentExpireScore.plus(additionalSeconds, ChronoUnit.SECONDS);
+        redisTemplate.opsForZSet().add(BOARD_RANK_KEY, key, newExpireScore.toEpochMilli());
 
         String boardName = key.split(Pattern.quote(BOARD_KEY_DELIMITER))[0];
         redisPublisher.publishRealTimeBoardTimeUpEvent(
@@ -182,7 +197,7 @@ public class BoardRedisService {
 
     @Transactional // 조회수, 좋아요 개수 데이터 동기화를 하나의 트랜잭션으로 묶는다.
     public BoardPagingResponseDto findAllRealTimeBoardPaging(
-        BoardPagingRequestDto boardPagingRequestDto) {
+            BoardPagingRequestDto boardPagingRequestDto) {
         // Redis에서의 조회는 0부터 시작하므로, size로 받은 숫자에서 1을 뺀 값을 사용한다.
         int start = boardPagingRequestDto.getPage() * boardPagingRequestDto.getSize();
         int end = start + boardPagingRequestDto.getSize() - 1;
@@ -200,56 +215,60 @@ public class BoardRedisService {
         postLikesService.syncLikesToDatabase();
 
         // DB에서 실시간 게시판 목록 조회
-        List<RealtimeBoardDto> realtimeBoardList = boardRepository.findRealtimeBoardsByIds(boardIdList);
+        List<RealtimeBoardDto> realtimeBoardList = boardRepository.findRealtimeBoardsByIds(
+                boardIdList);
 
         // Redis Pipeline을 이용해서 각 Board 별 TTL과 zScore 조회
         List<Object> results = getTtlAndScorePipeline(realtimeBoardList);
 
         // realtimeBoardList에 ttl과 zScore를 매핑
         IntStream.range(0, realtimeBoardList.size())
-            .forEach(i -> {
-                RealtimeBoardDto realtimeBoardDto = realtimeBoardList.get(i);
-                // result에 ttl과 zScore값이 번갈아가면서 들어있다. {ttl_0, zScore_0, ttl_1, zScore_1 ...}
-                realtimeBoardDto.setBoardLiveTime((Long) results.get(i * 2));
-                realtimeBoardDto.setScore((Double) results.get(i * 2 + 1));
-            });
+                .forEach(i -> {
+                    RealtimeBoardDto realtimeBoardDto = realtimeBoardList.get(i);
+                    // result에 ttl과 zScore값이 번갈아가면서 들어있다. {ttl_0, zScore_0, ttl_1, zScore_1 ...}
+                    realtimeBoardDto.setBoardLiveTime((Long) results.get(i * 2));
+                    realtimeBoardDto.setScore((Double) results.get(i * 2 + 1));
+                });
 
-        // boardLiveTime을 기준으로 1차 정렬, boardLiveTime이 같은 경우 score를 기준으로 2차 정렬
+        // boardLiveTime은 실시간 게시판이 Redis에 expire만 관리
+        // score을 사용해 실시간 게시판을 정렬하여 반환
         List<RealtimeBoardDto> sortedRealTimeBoardList = realtimeBoardList.stream()
-            .sorted(Comparator.comparingLong(RealtimeBoardDto::getBoardLiveTime).reversed()
-                .thenComparingDouble(RealtimeBoardDto::getScore))
-            .collect(Collectors.toList());
+                .sorted(Comparator.comparingDouble(RealtimeBoardDto::getScore)) // score 오름차순 정렬만 적용
+                .collect(Collectors.toList());
 
-        long realtimeBoardCount = boardCache.getBoardCacheEntryMap().estimatedSize(); // 캐시에서 실시간 게시판 목록의 사이즈 조회
-        long totalPages = (long) Math.ceil((double) realtimeBoardCount / boardPagingRequestDto.getSize());
+        long realtimeBoardCount = boardCache.getBoardCacheEntryMap()
+                .estimatedSize(); // 캐시에서 실시간 게시판 목록의 사이즈 조회
+        long totalPages = (long) Math.ceil(
+                (double) realtimeBoardCount / boardPagingRequestDto.getSize());
         return BoardPagingResponseDto.from(totalPages, realtimeBoardCount, sortedRealTimeBoardList);
     }
 
     private List<Object> getTtlAndScorePipeline(List<RealtimeBoardDto> realtimeBoardDtoList) {
         List<Object> results = redisTemplate.executePipelined(
-            (RedisCallback<Object>) connection -> {
-                for (RealtimeBoardDto dto : realtimeBoardDtoList) {
-                    String boardKey = dto.getBoardName() + BOARD_KEY_DELIMITER + dto.getBoardId();
-                    connection.keyCommands().ttl(boardKey.getBytes());
-                    connection.zSetCommands()
-                        .zScore(BOARD_RANK_KEY.getBytes(), boardKey.getBytes());
-                }
-                return null;
-            });
+                (RedisCallback<Object>) connection -> {
+                    for (RealtimeBoardDto dto : realtimeBoardDtoList) {
+                        String boardKey =
+                                dto.getBoardName() + BOARD_KEY_DELIMITER + dto.getBoardId();
+                        connection.keyCommands().ttl(boardKey.getBytes());
+                        connection.zSetCommands()
+                                .zScore(BOARD_RANK_KEY.getBytes(), boardKey.getBytes());
+                    }
+                    return null;
+                });
         return results;
     }
 
     private static List<Long> extractBoardIdList(Set<String> boardKeyList) {
         return boardKeyList.stream()
-            .map(key -> {
-                String[] parts = key.split(BOARD_KEY_DELIMITER);
-                if (parts.length < BOARD_KEY_PARTS_LENGTH) {
-                    return null;
-                }
-                return Long.parseLong(parts[BOARD_ID_INDEX]);
-            })
-            .filter(Objects::nonNull)
-            .toList();
+                .map(key -> {
+                    String[] parts = key.split(BOARD_KEY_DELIMITER);
+                    if (parts.length < BOARD_KEY_PARTS_LENGTH) {
+                        return null;
+                    }
+                    return Long.parseLong(parts[BOARD_ID_INDEX]);
+                })
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     public Set<String> getBoardRank(int start, int end) {

--- a/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordJob.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordJob.java
@@ -63,7 +63,9 @@ public class SignalKeywordJob implements Job {
                 Instant now = Instant.now();
                 Instant twoHoursLater = now.plus(2, ChronoUnit.HOURS);
                 long epochMilli = twoHoursLater.toEpochMilli(); // UTC 기준 2시간이 지난 시간을 밀리초로 변환
-                boardRedisService.saveBoardRedis(boardSaveDto, epochMilli + (i + 1) * 0.01);
+
+                double rank = (i + 1) * 0.01;
+                boardRedisService.saveBoardRedis(boardSaveDto, epochMilli + rank);
 
                 /* 동일 객체 참조로 내부 원본의 각 검색어의 게시판 ID를 포함하여 반환 */
                 top10WithChange.getTop10WithDiff().get(i).setBoardId(boardId);

--- a/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordJob.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/SignalKeywordJob.java
@@ -6,6 +6,8 @@ import com.trend_now.backend.board.dto.SignalKeywordDto;
 import com.trend_now.backend.board.dto.SignalKeywordEventDto;
 import com.trend_now.backend.board.dto.Top10;
 import com.trend_now.backend.board.dto.Top10WithChange;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.Job;
@@ -54,7 +56,14 @@ public class SignalKeywordJob implements Job {
 
                 Long boardId = boardService.saveBoardIfNotExists(boardSaveDto);
                 boardSaveDto.setBoardId(boardId);
-                boardRedisService.saveBoardRedis(boardSaveDto, i + 1);
+
+                // score 값을 현재 Instant 시간에서 2시간이 지난 값으로 설정하여 saveBoardRedis에 전달
+                // i는 10번을 순회하면서 첫 번째는 0.01, 두 번째는 0.02, ... , 열 번째는 0.1의 값을 위 시간에서 더한다
+
+                Instant now = Instant.now();
+                Instant twoHoursLater = now.plus(2, ChronoUnit.HOURS);
+                long epochMilli = twoHoursLater.toEpochMilli(); // UTC 기준 2시간이 지난 시간을 밀리초로 변환
+                boardRedisService.saveBoardRedis(boardSaveDto, epochMilli + (i + 1) * 0.01);
 
                 /* 동일 객체 참조로 내부 원본의 각 검색어의 게시판 ID를 포함하여 반환 */
                 top10WithChange.getTop10WithDiff().get(i).setBoardId(boardId);

--- a/backend/src/test/java/com/trend_now/backend/unit/board/service/BoardsRedisServiceTest.java
+++ b/backend/src/test/java/com/trend_now/backend/unit/board/service/BoardsRedisServiceTest.java
@@ -1,0 +1,201 @@
+package com.trend_now.backend.unit.board.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.trend_now.backend.board.application.BoardRedisService;
+import com.trend_now.backend.board.application.RedisPublisher;
+import com.trend_now.backend.board.cache.BoardCache;
+import com.trend_now.backend.board.cache.BoardCacheEntry;
+import com.trend_now.backend.board.dto.BoardPagingRequestDto;
+import com.trend_now.backend.board.dto.BoardPagingResponseDto;
+import com.trend_now.backend.board.dto.RealtimeBoardDto;
+import com.trend_now.backend.board.repository.BoardRepository;
+import com.trend_now.backend.post.application.PostLikesService;
+import com.trend_now.backend.post.application.PostViewService;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class BoardsRedisServiceTest {
+
+    private static final String BOARD_RANK_KEY = "board_rank";
+    private static final String BOARD_RANK_VALID_KEY = "board_rank_valid";
+    private static final String BOARD_THRESHOLD_KEY = "board_threshold";
+    private static final String BOARD_INITIAL_COUNT = "0";
+    public static final String BOARD_KEY_DELIMITER = ":";
+    public static final int BOARD_KEY_PARTS_LENGTH = 2;
+    public static final int BOARD_ID_INDEX = 1;
+    private static final long KEY_LIVE_TIME = 7201L;
+    private static final long BOARD_TIME_UP_50 = 300L;
+    private static final long BOARD_TIME_UP_100 = 600L;
+    private static final int KEY_EXPIRE = 0;
+    private static final int BOARD_TIME_UP_50_THRESHOLD = 50;
+    private static final int BOARD_TIME_UP_100_THRESHOLD = 100;
+    private static final int POSTS_INCREMENT_UNIT = 1;
+
+    @InjectMocks
+    private BoardRedisService boardRedisService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOps;
+
+    @Mock
+    private SetOperations<String, String> setOps;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOps;
+
+    @Mock
+    private RedisPublisher redisPublisher;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private BoardCache boardCache;
+
+    @Mock
+    private Cache<Long, BoardCacheEntry> mockCache;
+
+    @Mock
+    private PostLikesService postLikesService;
+
+    @Mock
+    private PostViewService postViewService;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        when(redisTemplate.opsForSet()).thenReturn(setOps);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+        when(boardCache.getBoardCacheEntryMap()).thenReturn(mockCache);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "49, 50, 300",  // 49 → 50개 돌파 → 300초 증가
+            "99, 100, 600"  // 99 → 100개 돌파 → 600초 증가
+    })
+    @DisplayName("실시간 게시판일 때, 게시판의 게시글 수가 일정 개수 이상된다면 해당 게시판의 남은 시간이 증가")
+    public void 실시간게시판_일정게시글수_남은시간증가(int initialCount, int threshold, long expectedTimeUp)
+            throws Exception {
+        //given
+        Long boardId = 1L;
+        String boardName = "testBoard";
+        String key = boardName + BOARD_KEY_DELIMITER + boardId;
+
+        // 실시간 게시판이면서 현재 남은 시간이 100초일 경우
+        when(redisTemplate.hasKey(key)).thenReturn(true);
+        when(redisTemplate.getExpire(key, TimeUnit.SECONDS)).thenReturn(100L);
+
+        // 현재 게시글의 수가 49개이면서 시간이 증가된 적이 없을 때
+        AtomicLong postCount = new AtomicLong(initialCount);
+        doAnswer(invocation -> {
+            // Mock을 사용하면 updatePostCountAndExpireTime()에서 increment()가 실행되어도 postCount가 증가하지 않음
+            // 1. mock은 실제 구현을 호출하지 않음
+            // 2. 내부 상태가 없음
+            // 3. 호출 사이의 인과관계가 자동으로 생기지 않음
+
+            // doAnswer()을 사용해 Mock에서도 postCount를 증가시킨다
+            Long delta = invocation.getArgument(1);
+            return postCount.addAndGet(delta);
+        }).when(valueOps).increment(anyString(), anyLong());
+        when(valueOps.get(anyString())).thenAnswer(invocation -> String.valueOf(postCount.get()));
+        when(setOps.isMember(anyString(), anyString())).thenReturn(false);
+        double currentScoreMillis = Instant.now().toEpochMilli();
+        when(zSetOps.score(anyString(), eq(key))).thenReturn(currentScoreMillis);
+
+        //when
+        boardRedisService.updatePostCountAndExpireTime(boardId, boardName);
+
+        //then
+        verify(valueOps).increment(key, 1);
+        verify(redisTemplate).expire(key, 100L + expectedTimeUp, TimeUnit.SECONDS);
+
+        Instant expectedScore = Instant.ofEpochMilli((long) currentScoreMillis)
+                .plus(expectedTimeUp, ChronoUnit.SECONDS);
+        verify(zSetOps).add(eq(BOARD_RANK_KEY), eq(key), eq((double) expectedScore.toEpochMilli()));
+        verify(setOps).add(eq(BOARD_THRESHOLD_KEY), contains(String.valueOf(threshold)));
+    }
+
+//    @Test
+//    @DisplayName("실시간 게시판 목록이 score 기준으로 오름차순 정렬된다")
+//    public void 실시간게시판_score_오름차순정렬() throws Exception {
+//        //given
+//        BoardPagingRequestDto boardPagingRequestDto = new BoardPagingRequestDto(0, 3);
+//
+//        Set<String> mockBoardKeys = new LinkedHashSet<>();
+//        mockBoardKeys.add("board1:1");
+//        mockBoardKeys.add("board2:2");
+//        mockBoardKeys.add("board3:3");
+//
+//        when(zSetOps.range(eq(BOARD_RANK_KEY), anyLong(), anyLong()))
+//                .thenReturn(mockBoardKeys);
+//        List<Long> boardIds = Arrays.asList(1L, 2L, 3L);
+//        List<RealtimeBoardDto> mockBoards = Arrays.asList(
+//                new RealtimeBoardDto(1L, "board1", 1L, 1L, LocalDateTime.now(),
+//                        LocalDateTime.now()),
+//                new RealtimeBoardDto(2L, "board2", 1L, 1L, LocalDateTime.now(),
+//                        LocalDateTime.now()),
+//                new RealtimeBoardDto(3L, "board3", 1L, 1L, LocalDateTime.now(), LocalDateTime.now())
+//        );
+//
+//        when(boardRepository.findRealtimeBoardsByIds(boardIds)).thenReturn(mockBoards);
+//
+//        List<Object> pipelineResults = Arrays.asList(
+//                Arrays.asList(300L, 20.0),   // 게시글1: ttl=300, score=20
+//                Arrays.asList(300L, 10.0),   // 게시글2: ttl=300, score=10
+//                Arrays.asList(300L, 30.0)    // 게시글3: ttl=300, score=30
+//        );
+//
+//        when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(pipelineResults);
+//        when(mockCache.estimatedSize()).thenReturn(3L);
+//
+//        //when
+//        BoardPagingResponseDto responseDto = boardRedisService.findAllRealTimeBoardPaging(
+//                boardPagingRequestDto);
+//
+//        //then
+//        List<RealtimeBoardDto> sortedBoards = responseDto.getBoardInfoDtos();
+//        Assertions.assertThat(sortedBoards).extracting("boardId").containsExactly(2L, 1L, 3L);
+//    }
+
+}


### PR DESCRIPTION
## 📌 PR 제목
[refactor][CCS-67] 실시간 게시판 score을 UTC 기준 시각을 사용하여 만료 시간으로 세팅하도록 변경

## 🔗 관련 이슈
- #123 

## ✍️ 변경 사항
- 실시간 게시판의 score 값이 UTC 기준 시각을 사용한 게시판 만료 시간으로 변경

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 아직 단위 테스트가 완성되지 않았는데 너무 늦어질 것 같아서 미리 PR 올리고 작업하려고 합니다.
- 제가 했을 때 기능에 문제는 없었는데 혹시나 문제가 있다면 말씀부탁드립니다.

[CCS-67]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ