### PR TITLE
[feat][CCS-65] Refresh Token 구현 #121

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/common/CookieUtil.java
+++ b/backend/src/main/java/com/trend_now/backend/common/CookieUtil.java
@@ -3,11 +3,19 @@ package com.trend_now.backend.common;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+@Slf4j
 public class CookieUtil {
+
+    private static final String REFERER = "Referer";
+    private static final String PREFIX_HTTPS = "https";
+    private static final String SET_COOKIE = "Set-Cookie";
+    private static final String LOCALHOST = "localhost";
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
@@ -19,13 +27,39 @@ public class CookieUtil {
         return Optional.empty();
     }
 
-    public static void addCookie(HttpServletResponse response, String name, String value,
+    /**
+     * Cookie 저장
+     * - 로컬 환경(http or localhost)과 배포 환경(https) 분기 처리하여 Cookie 저장 속성 지정
+     * - 해당 정보는 HTTP Referer 정보를 기반으로 판단
+     */
+    public static void addCookie(HttpServletRequest request, HttpServletResponse response, String name, String value,
         int maxAge) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
+        String sourceUrl = request.getHeader(REFERER);
+        boolean isProd = isProductionEnvironment(sourceUrl);
+
+        log.info("[CookieUtil.addCookie] sourceUrl = {}, 요청 환경 = {}", sourceUrl, isProd ? "배포 환경" : "개발 환경");
+
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(maxAge)
+                .secure(isProd)
+                .sameSite(isProd ? "None" : "Lax")
+                .build();
+
+        response.addHeader(SET_COOKIE, cookie.toString());
+    }
+
+    private static boolean isProductionEnvironment(String sourceUrl) {
+        return sourceUrl != null
+                && sourceUrl.startsWith(PREFIX_HTTPS)
+                && !isLocalEnvironment(sourceUrl);
+    }
+
+    private static boolean isLocalEnvironment(String sourceUrl) {
+        return sourceUrl.contains(LOCALHOST) ||
+                sourceUrl.contains("127.0.0.1") ||
+                sourceUrl.contains("0.0.0.0");
     }
 
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response,

--- a/backend/src/main/java/com/trend_now/backend/config/auth/oauth/CustomAuthorizationRequestRepository.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/oauth/CustomAuthorizationRequestRepository.java
@@ -29,12 +29,12 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
         }
         // 인가 요청 정보를 쿠키에 저장
         String serializedAuthRequest = Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(authorizationRequest));
-        CookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serializedAuthRequest, 180);
+        CookieUtil.addCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serializedAuthRequest, 180);
 
         // redirect_url를 별도 쿠키로 저장
         String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
         if (redirectUriAfterLogin != null) {
-            CookieUtil.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, 180);
+            CookieUtil.addCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, 180);
         }
     }
 

--- a/backend/src/main/java/com/trend_now/backend/config/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -58,8 +58,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             .orElse("/");
 
         // HttpOnly Cookie 방식으로 Access Token 저장하여 response에 지정
-        CookieUtil.addCookie(response, ACCESS_TOKEN_KEY, accessToken, accessTokenExpiration);
-        CookieUtil.addCookie(response, REFRESH_TOKEN_KEY, refreshToken, refreshTokenExpiration);
+        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, accessToken, accessTokenExpiration);
+        CookieUtil.addCookie(request, response, REFRESH_TOKEN_KEY, refreshToken, refreshTokenExpiration);
 
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)
             .build()

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -119,7 +119,7 @@ public class MemberService {
      * - test 계정이 없으면 해당 계정을 저장 후, id 값을 가져와 JWT 값 생성
      */
     @Transactional
-    public String getTestJwt(HttpServletResponse response) {
+    public String getTestJwt(HttpServletRequest request, HttpServletResponse response) {
         Members testMember = memberRepository.findBySnsId("test_snsId")
                 .orElseGet(
                         () -> memberRepository.save(
@@ -135,8 +135,8 @@ public class MemberService {
         String testJwt = jwtTokenProvider.createAccessToken(testMember.getId());
         String testRefreshToken = jwtTokenProvider.createRefreshToken(testMember.getId());
         log.info("[MemberService.getTestJwt] : 테스트용 JWT = {}, Refresh Token {}", testJwt, testRefreshToken);
-        CookieUtil.addCookie(response, ACCESS_TOKEN_KEY, testJwt, accessTokenExpiration);
-        CookieUtil.addCookie(response, REFRESH_TOKEN_KEY, testRefreshToken, refreshTokenExpiration);
+        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, testJwt, accessTokenExpiration);
+        CookieUtil.addCookie(request, response, REFRESH_TOKEN_KEY, testRefreshToken, refreshTokenExpiration);
         return testJwt;
     }
 
@@ -162,7 +162,7 @@ public class MemberService {
         // Redis에 key(Member Id)의 value(Refresh Token)이 입력된 Refresh Token과 일치하는지 확인
         if(memberRedisService.isMatchedRefreshTokenInRedis(memberIdInAccessToken, refreshToken.getValue())) {
             String reissuancedAccessToken = jwtTokenProvider.createAccessToken(memberIdInAccessToken);
-            CookieUtil.addCookie(response, ACCESS_TOKEN_KEY, reissuancedAccessToken, accessTokenExpiration);
+            CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, reissuancedAccessToken, accessTokenExpiration);
             return REISSUANCE_ACCESS_TOKEN_SUCCESS;
         } else {
             throw new NotFoundException(NOT_EXIST_MATCHED_REFRESH_TOKEN_IN_REDIS);

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -56,8 +56,8 @@ public class MemberController {
     // 테스트용 JWT 발급 API
     @GetMapping("/test-jwt")
     @Operation(summary = "JWT 발급", description = "테스트용 JWT 발급 API")
-    public ResponseEntity<String> getJwt(HttpServletResponse response) {
-        return new ResponseEntity<>(memberService.getTestJwt(response), HttpStatus.OK);
+    public ResponseEntity<String> getJwt(HttpServletRequest request, HttpServletResponse response) {
+        return new ResponseEntity<>(memberService.getTestJwt(request, response), HttpStatus.OK);
     }
 
     /**

--- a/backend/src/test/java/com/trend_now/backend/integration/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/trend_now/backend/integration/member/application/MemberServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -90,13 +91,14 @@ class MemberServiceTest {
         List<String> jwts = new ArrayList<>();
         Set<Long> memberIds = new HashSet<>();
 
-        // Mock HttpServletResponse 생성
+        // Mock HttpServletRequest, Response 생성
+        MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         // when
         // 테스트 JWT 생성 메서드를 count번 호출한다.
         for (int i = 0; i < count; i++) {
-            String jwt = memberService.getTestJwt(response);
+            String jwt = memberService.getTestJwt(request, response);
             jwts.add(jwt);
         }
 


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-65] Refresh Token 구현

## 🔗 관련 이슈
- #118 

## ✍️ 변경 사항
- 기존 방식에 https 환경에서 로그인 시, 토큰이 Cookie에 저장되지 않은 이슈가 있었습니다.
 
- http, https 요청에 따라 다음을 분기처리 했습니다.
- http의 경우, 개발 환경으로 판단하고 Secure 속성을 false,  sameSite 속성을 Lax 처리
- https의 경우, 배포 환경으로 판단하고 Secure 속성을 true, sameSite 속성을 None 처리

## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- 해당 방법에 대하여 피드백 부탁드립니다.

[CCS-65]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ