### PR TITLE
hotfix: 실시간 게시판의 개수 조회하는 방식 변경

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardRedisService.java
@@ -244,8 +244,7 @@ public class BoardRedisService {
                 return realtimeBoardDto;
             }).toList();
 
-        long realtimeBoardCount = boardCache.getBoardCacheEntryMap()
-            .estimatedSize(); // 캐시에서 실시간 게시판 목록의 사이즈 조회
+        Long realtimeBoardCount = redisTemplate.opsForZSet().zCard(BOARD_RANK_KEY);// 캐시에서 실시간 게시판 목록의 사이즈 조회
         long totalPages = (long) Math.ceil(
             (double) realtimeBoardCount / boardPagingRequestDto.getSize());
         return BoardPagingResponseDto.from(totalPages, realtimeBoardCount, realtimeBoardList);


### PR DESCRIPTION
캐싱 데이터 -> redis 직접 조회