### PR TITLE
[feat][CCS-65] Refresh Token 구현

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/JwtTokenFilter.java
@@ -44,7 +44,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
     private static final String ACCESS_TOKEN_KEY = "access_token";
     private static final String JWT_PREFIX = "Bearer ";
-    private static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+    private static final String INVALID_TOKEN_RETURN_MESSAGE = "Invalid Access Token";
     private static final String EXPIRED_TOKEN_RETURN_MESSAGE = "Expired Access Token";
 
     @Value("${jwt.access-token.secret}")
@@ -87,7 +87,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 // Access Token 검증 및 Claims 객체 추출
                 Claims claims = validateAccessToken(accessToken);
                 if (claims == null) {
-                    throw new InvalidTokenException(INVALID_TOKEN);
+                    throw new InvalidTokenException(INVALID_TOKEN_RETURN_MESSAGE);
                 }
 
                 // Access Token 만료기간 검증 (accessTokenExpiration 변수 사용)
@@ -101,7 +101,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                     }
                 } else {
                     // issuedAt 자체가 없으면 JWT 예외로 판단
-                    throw new InvalidTokenException(INVALID_TOKEN);
+                    throw new InvalidTokenException(INVALID_TOKEN_RETURN_MESSAGE);
                 }
 
                 /**
@@ -152,7 +152,19 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             e.printStackTrace();
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType("application/json");
-            response.getWriter().write("invalid token");
+
+            // 요청 path 가져오기
+            String path = request.getRequestURI();
+
+            // DTO 생성
+            ErrorResponseDto errorResponse = new ErrorResponseDto(
+                    HttpStatus.UNAUTHORIZED,
+                    INVALID_TOKEN_RETURN_MESSAGE,
+                    path
+            );
+
+            // JSON 직렬화
+            new ObjectMapper().writeValue(response.getWriter(), errorResponse);
         }
     }
 

--- a/backend/src/main/java/com/trend_now/backend/config/auth/oauth/OAuth2LoginSuccessHandler.java
+++ b/backend/src/main/java/com/trend_now/backend/config/auth/oauth/OAuth2LoginSuccessHandler.java
@@ -33,6 +33,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private static final String ACCESS_TOKEN_KEY = "access_token";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
+    private static final int ONE_YEAR = 365*24*60*60;   // 1년을 초로 변환
 
     @Value("${jwt.access-token.expiration}")
     private int accessTokenExpiration;
@@ -58,7 +59,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             .orElse("/");
 
         // HttpOnly Cookie 방식으로 Access Token 저장하여 response에 지정
-        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, accessToken, accessTokenExpiration);
+        // Access Token의 경우 1년의 만료 기간을 설정하여 브라우저에서는 무한히 지속되는 효과 부여
+        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, accessToken, ONE_YEAR);
         CookieUtil.addCookie(request, response, REFRESH_TOKEN_KEY, refreshToken, refreshTokenExpiration);
 
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUrl)

--- a/backend/src/main/java/com/trend_now/backend/exception/CustomException/ExpiredTokenException.java
+++ b/backend/src/main/java/com/trend_now/backend/exception/CustomException/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package com.trend_now.backend.exception.CustomException;
+
+/**
+ * 만료된 Access Token으로 API 요청 시, 해당 예외가 발생
+ */
+public class ExpiredTokenException extends RuntimeException {
+
+    public ExpiredTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberRedisService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberRedisService.java
@@ -50,4 +50,11 @@ public class MemberRedisService {
 
         return refreshTokenInRedis.equals(refreshToken);
     }
+
+    /**
+     * Redis 내부의 key에 해당되는 value 삭제
+     */
+    public void delete(String key) {
+        redisTemplate.delete(REFRESH_TOKEN_PREFIX + key);
+    }
 }

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -48,8 +48,8 @@ public class MemberService {
     private final MemberRedisService memberRedisService;
     private final JwtTokenFilter jwtTokenFilter;
 
-    @Value("${jwt.access-token.expiration}")
-    private int accessTokenExpiration;
+//    @Value("${jwt.access-token.expiration}")
+//    private int accessTokenExpiration;
 
     @Value("${jwt.refresh-token.expiration}")
     private int refreshTokenExpiration;
@@ -163,7 +163,7 @@ public class MemberService {
         // Redis에 key(Member Id)의 value(Refresh Token)이 입력된 Refresh Token과 일치하는지 확인
         if(memberRedisService.isMatchedRefreshTokenInRedis(memberIdInAccessToken, refreshToken.getValue())) {
             String reissuancedAccessToken = jwtTokenProvider.createAccessToken(memberIdInAccessToken);
-            CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, reissuancedAccessToken, accessTokenExpiration);
+            CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, reissuancedAccessToken, ONE_YEAR);
             return REISSUANCE_ACCESS_TOKEN_SUCCESS;
         } else {
             throw new NotFoundException(NOT_EXIST_MATCHED_REFRESH_TOKEN_IN_REDIS);

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -39,6 +39,7 @@ public class MemberService {
     private static final String REISSUANCE_ACCESS_TOKEN_FAIL = "Access Token 재발급에 실패하였습니다.";
     private static final String NOT_EXIST_ACCESS_TOKEN = "Access Token이 존재하지 않습니다.";
     private static final String NOT_EXIST_REFRESH_TOKEN = "Refresh Token이 존재하지 않습니다.";
+    private static final int ONE_YEAR = 365*24*60*60;   // 1년을 초로 변환
 
     private final MemberRepository memberRepository;
     private final PostsRepository postsRepository;
@@ -135,7 +136,7 @@ public class MemberService {
         String testJwt = jwtTokenProvider.createAccessToken(testMember.getId());
         String testRefreshToken = jwtTokenProvider.createRefreshToken(testMember.getId());
         log.info("[MemberService.getTestJwt] : 테스트용 JWT = {}, Refresh Token {}", testJwt, testRefreshToken);
-        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, testJwt, accessTokenExpiration);
+        CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, testJwt, ONE_YEAR);
         CookieUtil.addCookie(request, response, REFRESH_TOKEN_KEY, testRefreshToken, refreshTokenExpiration);
         return testJwt;
     }

--- a/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/trend_now/backend/member/application/MemberService.java
@@ -40,6 +40,8 @@ public class MemberService {
     private static final String NOT_EXIST_ACCESS_TOKEN = "Access Token이 존재하지 않습니다.";
     private static final String NOT_EXIST_REFRESH_TOKEN = "Refresh Token이 존재하지 않습니다.";
     private static final int ONE_YEAR = 365*24*60*60;   // 1년을 초로 변환
+    private static final String LOGOUT_SUCCESS = "로그아웃에 성공하였습니다.";
+    private static final String LOGOUT_FAIL = "로그아웃에 실패하였습니다.";
 
     private final MemberRepository memberRepository;
     private final PostsRepository postsRepository;
@@ -167,6 +169,27 @@ public class MemberService {
             return REISSUANCE_ACCESS_TOKEN_SUCCESS;
         } else {
             throw new NotFoundException(NOT_EXIST_MATCHED_REFRESH_TOKEN_IN_REDIS);
+        }
+    }
+
+    /**
+     * 로그아웃
+     * - Redis의 Refresh Token 부분을 삭제
+     * - Cookie 측에 Access Token과 Refresh Token 부분을 삭제
+     */
+    public String logout(HttpServletRequest request, HttpServletResponse response, Members member) {
+        try {
+            // Redis에 key(Member Id)의 value(Refresh Token) 부분을 삭제
+            memberRedisService.delete(String.valueOf(member.getId()));
+
+            // Cookie 측에 Access Token과 Refresh Token 삭제
+            CookieUtil.addCookie(request, response, ACCESS_TOKEN_KEY, null, 0);
+            CookieUtil.addCookie(request, response, REFRESH_TOKEN_KEY, null, 0);
+
+            return LOGOUT_SUCCESS;
+        } catch (Exception e) {
+            log.error("[MemberService.logout] 로그아웃 에러 = {}", e.getMessage());
+            return LOGOUT_FAIL;
         }
     }
 }

--- a/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/trend_now/backend/member/presentation/MemberController.java
@@ -152,4 +152,13 @@ public class MemberController {
             HttpServletResponse response) {
         return new ResponseEntity<>(memberService.reissuanceAccessToken(request, response), HttpStatus.OK);
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "로그아웃을 진행합니다.")
+    public ResponseEntity<String> logout(
+            @AuthenticationPrincipal(expression = "members") Members member,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return new ResponseEntity<>(memberService.logout(request, response, member), HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-65] Refresh Token 구현

## 🔗 관련 이슈
- #118 

## ✍️ 변경 사항
이슈
- AT 재발급 요청 시, 만료된 AT 쿠키는 삭제되어 보낼 수가 없음
    - 기존에 만료된 AT에서 memberId를 식별하도록 로직을 구상했음

로그인 로직 구상
- HttpResponse에 AT 쿠키는 영원히 지속되도록 처리하고, RF 쿠키만 만료 시간을 부여
    - 해당 경우에는 AT 쿠키는 Session 쿠키와 Permanent 쿠키 중 하나를 선택해야 함.
        - Session 쿠키는 브라우저가 닫히면 같이 삭제되는 쿠키, Permanent 쿠키는 브라우저가 닫혀도 지정한 만료 시간까지 살아있는 쿠키
    - AT 쿠키의 경우 만료시간을 1년으로 처리

AT 토큰 필터 구상
- API 요청에서 사용되는 AT 만료 기간 검증은 application.yml 의 환경변수에 지정된 값을 사용해서 만료 여부 파악

AT 재발급 로직
- 현재 AT 재발급은 만료된 AT를 받아서 memberId를 식별
    - 지금도 가능하므로 변경점은 없을 듯
- AT 쿠키 만료기간만 1년으로 수정

로그아웃 로직 구상
- 로그아웃 API가 요청되면 해당 memberId를 기반으로 Redis의 “RefreshToken_[memberId]” key 삭제
- HttpResponse에 Cookie 삭제되는 로직을 포함시켜서 반환


## ✅ 체크리스트
- [X] PR 제목이 적절한가요?
- [X] 관련 이슈가 연결되었나요?
- [X] 변경 사항을 충분히 설명했나요?
- [X] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)