### PR TITLE
[feat][CCS-71] 이전 키워드와 유사한 키워드는 게시판 이름만 변경하고 같은 게시판으로 취급

### DIFF
--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
@@ -37,7 +37,7 @@ public class BoardService {
             board.changeDeleted();
             return board;
         } else {
-            // 기존 게시판들과 유사도 검증
+            // 기존 게시판들과 유사도 검증 (비슷한 이름의 게시판이 있으면 해당 게시판의 이름 반환, 없으면 입력받은 이름 그대로 반환)
             String similarBoard = boardCache.findKeywordSimilarity(boardSaveDto.getBoardName());
 
             // 비슷한 이름의 게시판이 존재하면 이름 업데이트

--- a/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
+++ b/backend/src/main/java/com/trend_now/backend/board/application/BoardService.java
@@ -37,7 +37,18 @@ public class BoardService {
             board.changeDeleted();
             return board;
         } else {
-            // 새로운 게시판일 경우 새로운 객체 생성 후 저장
+            // 기존 게시판들과 유사도 검증
+            String similarBoard = boardCache.findKeywordSimilarity(boardSaveDto.getBoardName());
+
+            // 비슷한 이름의 게시판이 존재하면 이름 업데이트
+            if (!similarBoard.equals(boardSaveDto.getBoardName())) {
+                Boards board = boardRepository.findByName(similarBoard)
+                    .orElseThrow(() -> new NotFoundException(BOARD_NOT_FOUND_MESSAGE));
+                board.updateName(boardSaveDto.getBoardName());
+                return board;
+            }
+
+            // 비슷한 게시판이 존재하지 않으면 새로운 게시판 저장
             return boardRepository.save(
                 Boards.builder()
                     .name(boardSaveDto.getBoardName())

--- a/backend/src/main/java/com/trend_now/backend/board/cache/BoardCache.java
+++ b/backend/src/main/java/com/trend_now/backend/board/cache/BoardCache.java
@@ -121,6 +121,10 @@ public class BoardCache {
         return boardCacheEntryMap.getIfPresent(boardId) != null;
     }
 
+    /**
+     * 키워드와 유사한 게시판 이름이 존재하는지 확인하고, 유사한 게시판이 있으면 해당 이름을 반환.
+     * 유사한 게시판이 없으면 입력 값으로 들어온 키워드를 그대로 반환.
+     */
     public String findKeywordSimilarity(String newKeyword) {
         Set<String> newSet = Arrays.stream(newKeyword.split(BLANK))
             .collect(Collectors.toSet());

--- a/backend/src/main/java/com/trend_now/backend/board/cache/BoardCacheEntry.java
+++ b/backend/src/main/java/com/trend_now/backend/board/cache/BoardCacheEntry.java
@@ -1,6 +1,7 @@
 package com.trend_now.backend.board.cache;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,6 +10,7 @@ import lombok.Getter;
 public class BoardCacheEntry {
 
     private String boardName;
+    private Set<String> splitBoardName; // 문자열 유사도 비교를 위한 Set
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/backend/src/main/java/com/trend_now/backend/board/domain/Boards.java
+++ b/backend/src/main/java/com/trend_now/backend/board/domain/Boards.java
@@ -44,4 +44,8 @@ public class Boards extends BaseEntity {
     public void changeDeleted() {
         this.deleted = !this.deleted;
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/test/java/com/trend_now/backend/integration/comment/application/CommentsServiceTest.java
+++ b/backend/src/test/java/com/trend_now/backend/integration/comment/application/CommentsServiceTest.java
@@ -15,7 +15,7 @@ import com.trend_now.backend.comment.data.dto.SaveCommentsDto;
 import com.trend_now.backend.comment.data.dto.UpdateCommentsDto;
 import com.trend_now.backend.comment.domain.Comments;
 import com.trend_now.backend.comment.repository.CommentsRepository;
-import com.trend_now.backend.global.exception.CustomException.InvalidRequestException;
+import com.trend_now.backend.exception.customException.InvalidRequestException;
 import com.trend_now.backend.member.domain.Members;
 import com.trend_now.backend.member.domain.Provider;
 import com.trend_now.backend.member.repository.MemberRepository;

--- a/backend/src/test/java/com/trend_now/backend/integration/comment/presentation/CommentsControllerTest.java
+++ b/backend/src/test/java/com/trend_now/backend/integration/comment/presentation/CommentsControllerTest.java
@@ -5,7 +5,7 @@ import com.trend_now.backend.board.domain.Boards;
 import com.trend_now.backend.board.repository.BoardRepository;
 import com.trend_now.backend.comment.data.vo.SaveCommentsRequest;
 import com.trend_now.backend.comment.presentation.CommentsController;
-import com.trend_now.backend.global.exception.CustomException.NotFoundException;
+import com.trend_now.backend.exception.customException.NotFoundException;
 import com.trend_now.backend.member.domain.Members;
 import com.trend_now.backend.member.domain.Provider;
 import com.trend_now.backend.member.repository.MemberRepository;


### PR DESCRIPTION
## 📌 PR 제목
[feat][CCS-71] 이전 키워드와 유사한 키워드는 게시판 이름만 변경하고 같은 게시판으로 취급

## 🔗 관련 이슈
- #170 

## ✍️ 변경 사항
- 자카드 유사도 알고리즘을 활용해 문자열 유사도 추출
- 0.3 이상의 유사도를 가지면 같은 게시판으로 취급하고 새로운 키워드로 게시판 이름을 변경한다

## ✅ 체크리스트
- [x] PR 제목이 적절한가요?
- [x] 관련 이슈가 연결되었나요?
- [x] 변경 사항을 충분히 설명했나요?
- [x] 코드가 정상적으로 동작하나요?

## 💬 리뷰 요구 사항 (선택)
- treshold를 0.3으로 설정해놨습니다. 즉, 공백 기준으로 문자열을 나눴을 때 2개 이상의 교집합이 생기면 같은 게시판으로 취급합니다. 이 정도의 treshold이면 괜찮을까요 ?

ex) 
1. "트렌드나우 아자아자 화이팅", "Trendnow 아자 화이팅" 일 경우 0.3 미만
2. "트렌드나우 아자아자 화이팅", "Trendnow 아자아자 화이팅" 일 경우 0.3 이상

[CCS-71]: https://choemingyu47-1741326353289.atlassian.net/browse/CCS-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ